### PR TITLE
Make -raw a flag

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -120,6 +120,7 @@ type genCmd struct {
 	fCompat          *bool
 	fPullImage       *string
 	fPreStepDockExec *string
+	fRaw             *bool
 }
 
 func newGenCmd() *genCmd {
@@ -132,6 +133,7 @@ func newGenCmd() *genCmd {
 		res.fCompat = fs.Bool("compat", false, "render old-style PWD code blocks")
 		res.fPullImage = fs.String("pull", os.Getenv("PREGUIDE_PULL_IMAGE"), "try and docker pull image if missing")
 		res.fPreStepDockExec = fs.String("prestep", os.Getenv("PREGUIDE_PRESTEP_DOCKEXEC"), "the image and docker flags passed to dockexec when running the pre-step (if there is one)")
+		res.fRaw = fs.Bool("raw", false, "generate raw output for steps")
 	})
 	return res
 }

--- a/out/out.cue
+++ b/out/out.cue
@@ -32,11 +32,10 @@ package out
 }
 
 #Stmt: {
-	Negated:   bool
-	CmdStr:    string
-	ExitCode:  int
-	Output:    string
-	RawOutput: string
+	Negated:  bool
+	CmdStr:   string
+	ExitCode: int
+	Output:   string
 }
 
 #UploadStep: {

--- a/step.go
+++ b/step.go
@@ -51,7 +51,6 @@ type commandStmt struct {
 	CmdStr      string
 	ExitCode    int
 	Output      string
-	RawOutput   string
 	outputFence string
 
 	sanitisers []sanitiser

--- a/testdata/help.txt
+++ b/testdata/help.txt
@@ -62,5 +62,7 @@ usage: preguide gen
 	        the image and docker flags passed to dockexec when running the pre-step (if there is one)
 	  -pull string
 	        try and docker pull image if missing
+	  -raw
+	        generate raw output for steps
 	  -skipcache
 	        whether to skip any output cache checking

--- a/testdata/raw.txt
+++ b/testdata/raw.txt
@@ -1,0 +1,51 @@
+# Test that we get the expected output when using -raw
+
+# A run should generate stdout but no out/gen_out.cue file
+preguide gen -raw -out _output
+cmp stdout raw/stdout
+! stderr .+
+! exists raw/out/gen_out.cue
+
+-- raw/en.markdown --
+---
+title: A test with raw output
+---
+
+<!--step: step1 -->
+-- raw/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Image: "this_will_never_be_used"
+
+Steps: step1: en: preguide.#Command & { Source: """
+echo -n "Hello, world!"
+"""}
+-- raw/stdout --
+package out
+
+{
+	PreStep: {
+		Package: ""
+		Version: ""
+	}
+	Image: "playwithgo/go1.14.3@sha256:6289a34af0112146e551790d9f2a36622e083600752a02d36f1ad1f9e1389382"
+	Langs: {
+		en: {
+			Steps: {
+				step1: {
+					Name:  "step1"
+					Order: 0
+					Stmts: [{
+						Negated:  false
+						CmdStr:   "echo -n \"Hello, world!\""
+						ExitCode: 0
+						Output:   "Hello, world!"
+					}]
+				}
+			}
+			Hash: "114eb1f07460f7344b25f960234c04ba2d5eb93d34d4f6a80b3702b41034ea90"
+		}
+	}
+}


### PR DESCRIPTION
Including raw output in the gen_out.cue file never really made any
sense, because it means the output is not guaranteed to be stable (which
in the context of committing generated files makes no sense).