### PR TITLE
Embed preguide packages in preguide itself

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1,0 +1,3 @@
+package main
+
+//go:generate go run cuelang.org/go/cmd/cue cmd embed github.com/play-with-go/preguide

--- a/gen_cue.go
+++ b/gen_cue.go
@@ -1,0 +1,6 @@
+package main
+
+// CUEDef is the string quoted output of cue def for the current package. This
+// constant exists as a workaround until the full intent and capability of
+// cuelang.org/go/encoding/gocode/... is established.
+const CUEDef = "package preguide\n\n#Guide: {\n\tPreStep?: {\n\t\tPackage: string\n\t\tArgs: [...string]\n\t}\n\t// We can't make this conditional on len(Steps) because\n\t// of cuelang.org/issue/279. Hence we validate in code\n\tImage?: string\n\tSteps: [string]: en: #Command | #CommandFile | #Upload | #UploadFile\n\tDefs: {\n\t\t...\n\t}\n}\n#Command: {\n\t#IsCommand: true\n\tSource:     string\n}\n#CommandFile: {\n\t#IsCommandFile: true\n\tPath:           string\n}\n#Upload: {\n\tSource:    string\n\t#IsUpload: true\n\tTarget:    string\n}\n#UploadFile: {\n\tPath:      string\n\t#IsUpload: true\n\tTarget:    string\n}\n"

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"cuelang.org/go/cue/token"
 	"cuelang.org/go/encoding/gocode/gocodec"
 	"github.com/gohugoio/hugo/parser/pageparser"
+	"github.com/play-with-go/preguide/out"
 	"golang.org/x/net/html"
 )
 
@@ -163,16 +164,10 @@ func (r *runner) debugf(format string, args ...interface{}) {
 }
 
 func (r *runner) loadSchemas() {
-	pkgs := []string{"github.com/play-with-go/preguide", "github.com/play-with-go/preguide/out"}
-	bps := load.Instances(pkgs, nil)
-	var insts []*cue.Instance
-	for i, pkg := range pkgs {
-		check(bps[i].Err, "failed to load %v: %v", pkg, bps[i].Err)
-		inst, err := r.runtime.Build(bps[i])
-		check(err, "failed to build %v: %v", pkg, err)
-		insts = append(insts, inst)
-	}
-	preguide, preguideOut := insts[0], insts[1]
+	preguide, err := r.runtime.Compile("schema.cue", CUEDef)
+	check(err, "failed to compile github.com/play-with-go/preguide package: %v", err)
+	preguideOut, err := r.runtime.Compile("schema.cue", out.CUEDef)
+	check(err, "failed to compile github.com/play-with-go/preguide/out package: %v", err)
 
 	r.guideDef = preguide.LookupDef("#Guide")
 	r.commandDef = preguide.LookupDef("#Command")
@@ -619,7 +614,7 @@ func (r *runner) loadSteps(g *guide) {
 			// absorb this error - we have nothing to do
 			return
 		}
-		check(gp.Err, "failed to load CUE package in %v: %T", g.dir, gp.Err)
+		check(gp.Err, "failed to load CUE package in %v: %v", g.dir, gp.Err)
 	}
 
 	gi, err := r.runtime.Build(gp)

--- a/main_test.go
+++ b/main_test.go
@@ -52,6 +52,12 @@ func TestScripts(t *testing.T) {
 			err = os.Mkdir(newTmp, 0777)
 			check(err, "failed to create %v: %v", newTmp, err)
 
+			// Despite the fact that preguide embeds the definitions it needs,
+			// it's more convenient to write guides' CUE packages and have them
+			// import the preguide packages, for validation etc. That is to say,
+			// if we _didn't_ import the preguide packages as part of a guide's
+			// CUE package we would not be able to validate, code complete etc
+			// independent of running preguide itself (which isn't ideal)
 			err = modInit(env.WorkDir)
 			check(err, "failed to mod init: %v", err)
 

--- a/out/gen.go
+++ b/out/gen.go
@@ -1,0 +1,3 @@
+package out
+
+//go:generate go run cuelang.org/go/cmd/cue cmd embed github.com/play-with-go/preguide

--- a/out/gen_cue.go
+++ b/out/gen_cue.go
@@ -1,0 +1,6 @@
+package out
+
+// CUEDef is the string quoted output of cue def for the current package. This
+// constant exists as a workaround until the full intent and capability of
+// cuelang.org/go/encoding/gocode/... is established.
+const CUEDef = "package out\n\n#GuideOutput: {\n\tPreStep: {\n\t\tPackage: string\n\t\tVersion: string\n\t\tBuildID: string\n\t\tArgs: [...string]\n\t}\n\tImage: string\n\tLangs: #Langs\n\tDefs: {\n\t\t...\n\t}\n}\n#Langs: {\n\ten: #LangSteps\n}\n#LangSteps: {\n\tHash:  string\n\tSteps: #Steps\n}\n#Steps: {\n\t[string]: #CommandStep | #UploadStep\n}\n#CommandStep: {\n\tName:  string\n\tOrder: int\n\tStmts: [...#Stmt]\n}\n#UploadStep: {\n\tName:   string\n\tOrder:  int\n\tSource: string\n\tTarget: string\n}\n#Stmt: {\n\tNegated:  bool\n\tCmdStr:   string\n\tExitCode: int\n\tOutput:   string\n}\n"

--- a/preguide_tool.cue
+++ b/preguide_tool.cue
@@ -1,0 +1,32 @@
+package preguide
+
+import (
+	"tool/exec"
+	"tool/file"
+	"tool/os"
+	"strconv"
+)
+
+command: embed: {
+	gen: exec.Run & {
+		cmd: ["go", "run", "cuelang.org/go/cmd/cue", "def"]
+		stdout: string
+	}
+
+	pkg: os.Getenv & {
+		GOPACKAGE: string
+	}
+
+	embed: file.Create & {
+		filename: "gen_cue.go"
+		contents: """
+		package \(pkg.GOPACKAGE)
+
+		// CUEDef is the string quoted output of cue def for the current package. This
+		// constant exists as a workaround until the full intent and capability of
+		// cuelang.org/go/encoding/gocode/... is established.
+		const CUEDef = \(strconv.Quote(gen.stdout))
+
+		"""
+	}
+}


### PR DESCRIPTION
Theoretically it is possible to write a CUE package for a guide without
importing the preguide CUE packages: the only validation that ultimately
matters is when preguide itself runs. Hence it's possible that a user
(guide author) might not actually have the preguide packages available
via their cue.mod (they might only be depending on the preguide Go main
package).

In this case we cannot rely on being able to load the preguide packages
for validation purposes at runtime.

Hence we embed those two packages in preguide itself.

Note the tests themselves are written with guides that _do_ import the
preguide packages, hence we need to continue to vendor preguide itself
as part of each testscript script. Added a comment to this effect.