### PR TITLE
Sanitise prestep vars as {{.ENV}}

### DIFF
--- a/guide.go
+++ b/guide.go
@@ -145,7 +145,7 @@ func (g *guide) sanitiseVars(s string) string {
 	for _, repl := range g.vars {
 		parts := strings.SplitN(repl, "=", 2)
 		v, val := parts[0], parts[1]
-		s = strings.ReplaceAll(s, val, "$"+v)
+		s = strings.ReplaceAll(s, val, fmt.Sprintf("{{.%v}}", v))
 	}
 	return s
 }

--- a/testdata/prestep.txt
+++ b/testdata/prestep.txt
@@ -90,7 +90,7 @@ title: A test with all directives
 
 ```.term1
 $ echo "The answer is: $GREETING!"
-The answer is: $GREETING!
+The answer is: {{.GREETING}}!
 ```
 -- prestep/en_testlog.txt.golden --
 Image: playwithgo/go1.14.6@sha256:b3690d0dc29edfe2d740d3632175da32bc7301b8bec994060c11deaf99c71123
@@ -104,7 +104,7 @@ Presteps: [
   }
 ]
 $ echo "The answer is: $GREETING!"
-The answer is: $GREETING!
+The answer is: {{.GREETING}}!
 -- prestep/en.markdown.other.golden --
 ---
 image: playwithgo/go1.14.6@sha256:b3690d0dc29edfe2d740d3632175da32bc7301b8bec994060c11deaf99c71123


### PR DESCRIPTION
This prepares for a later change where the frontend will substitute
prose and scripts containing these templates with the values unique to
that guide instance.