### PR TITLE
Provide option to drive whether CUEDef generated embedding is exported

### DIFF
--- a/gen_cue.go
+++ b/gen_cue.go
@@ -1,6 +1,6 @@
 package main
 
-// CUEDef is the string quoted output of cue def for the current package. This
+// cueDef is the string quoted output of cue def for the current package. This
 // constant exists as a workaround until the full intent and capability of
 // cuelang.org/go/encoding/gocode/... is established.
-const CUEDef = "package preguide\n\n#Guide: {\n\tPresteps: [...#Prestep]\n\n\t// We can't make this conditional on len(Steps) because\n\t// of cuelang.org/issue/279. Hence we validate in code\n\tImage?: string\n\tSteps: [string]: en: #Command | #CommandFile | #Upload | #UploadFile\n\tDefs: {\n\t\t...\n\t}\n}\n#Prestep: {\n\tPackage: string\n\tArgs: [...string]\n}\n#Command: {\n\t#IsCommand: true\n\tSource:     string\n}\n#CommandFile: {\n\t#IsCommandFile: true\n\tPath:           string\n}\n#Upload: {\n\tSource:    string\n\t#IsUpload: true\n\tTarget:    string\n}\n#UploadFile: {\n\tPath:      string\n\t#IsUpload: true\n\tTarget:    string\n}\n"
+const cueDef = "package preguide\n\n#Guide: {\n\tPresteps: [...#Prestep]\n\n\t// We can't make this conditional on len(Steps) because\n\t// of cuelang.org/issue/279. Hence we validate in code\n\tImage?: string\n\tSteps: [string]: en: #Command | #CommandFile | #Upload | #UploadFile\n\tDefs: {\n\t\t...\n\t}\n}\n#Prestep: {\n\tPackage: string\n\tArgs: [...string]\n}\n#Command: {\n\t#IsCommand: true\n\tSource:     string\n}\n#CommandFile: {\n\t#IsCommandFile: true\n\tPath:           string\n}\n#Upload: {\n\tSource:    string\n\t#IsUpload: true\n\tTarget:    string\n}\n#UploadFile: {\n\tPath:      string\n\t#IsUpload: true\n\tTarget:    string\n}\n"

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func (r *runner) debugf(format string, args ...interface{}) {
 }
 
 func (r *runner) loadSchemas() {
-	preguide, err := r.runtime.Compile("schema.cue", CUEDef)
+	preguide, err := r.runtime.Compile("schema.cue", cueDef)
 	check(err, "failed to compile github.com/play-with-go/preguide package: %v", err)
 	preguideOut, err := r.runtime.Compile("schema.cue", out.CUEDef)
 	check(err, "failed to compile github.com/play-with-go/preguide/out package: %v", err)

--- a/out/gen.go
+++ b/out/gen.go
@@ -1,3 +1,3 @@
 package out
 
-//go:generate go run cuelang.org/go/cmd/cue cmd embed github.com/play-with-go/preguide
+//go:generate go run cuelang.org/go/cmd/cue cmd --inject export=true embed github.com/play-with-go/preguide

--- a/preguide_tool.cue
+++ b/preguide_tool.cue
@@ -7,6 +7,15 @@ import (
 	"strconv"
 )
 
+exportCUEDef: *false | bool @tag(export,type=bool)
+#CUEDefName:  string
+if exportCUEDef == true {
+	#CUEDefName: "CUEDef"
+}
+if exportCUEDef == false {
+	#CUEDefName: "cueDef"
+}
+
 command: embed: {
 	gen: exec.Run & {
 		cmd: ["go", "run", "cuelang.org/go/cmd/cue", "def"]
@@ -22,10 +31,10 @@ command: embed: {
 		contents: """
 		package \(pkg.GOPACKAGE)
 
-		// CUEDef is the string quoted output of cue def for the current package. This
+		// \(#CUEDefName) is the string quoted output of cue def for the current package. This
 		// constant exists as a workaround until the full intent and capability of
 		// cuelang.org/go/encoding/gocode/... is established.
-		const CUEDef = \(strconv.Quote(gen.stdout))
+		const \(#CUEDefName) = \(strconv.Quote(gen.stdout))
 
 		"""
 	}


### PR DESCRIPTION
The embedding of CUE is a workaround until such a time as a better
solution for runtime discovering of the CUE associated with a given type
is established.

For now we make it configurable whether the generated const is exported
or not.