### PR TITLE
Rename GenConfig to more generic PrestepServiceConfig

### DIFF
--- a/gencmd.go
+++ b/gencmd.go
@@ -38,7 +38,7 @@ import (
 // of markdown files of prose, one per language, that reference directives
 // defined in a CUE package located in d. The markdown files and CUE package
 // represent the input to the gen command. The gen command is configured by
-// CUE-specified configuration that follows the #GenConfig schema.
+// CUE-specified configuration that follows the #PrestepServiceConfig schema.
 //
 // The gen command processes each directory d in turn. gen tries to evaluate a
 // CUE package ./d/out to determine whether a guide's steps need to be re-run.
@@ -60,13 +60,14 @@ import (
 //
 // Hence for now we adopt the simple approach of dual-maintaining Go types and
 // CUE definitions for configuration types
-// (github.com/play-with-go/preguide.genConfig ->
-// github.com/play-with-go/preguide.#GenConfig), the input types
+// (github.com/play-with-go/preguide/internal/types.PrestepServiceConfig ->
+// github.com/play-with-go/preguide.#PrestepServiceConfig), the input types
 // (github.com/play-with-go/preguide/internal/types ->
 // github.com/play-with-go/preguide) and the output types
 // (github.com/play-with-go/preguide -> github.com/play-with-go/preguide/out).
-// Theoretically we could code generate from genConfig -> #GenConfig, however
-// it's not really worth it given we are dual-maintaining the rest already.
+// Theoretically we could code generate from
+// internal/types.PrestepServiceConfig -> #PrestepServiceConfig, however it's
+// not really worth it given we are dual-maintaining the rest already.
 //
 // Given that we cannot automatically extract CUE definitions from Go types,
 // there is then a gap when it comes to runtime validation of
@@ -96,7 +97,7 @@ type genCmd struct {
 
 	// config is parse configuration that results from unifying all the provided
 	// config (which can be multiple CUE inputs)
-	config types.GenConfig
+	config types.PrestepServiceConfig
 }
 
 func newGenCmd() *genCmd {
@@ -196,7 +197,7 @@ func (r *runner) loadSchemas() {
 		return v
 	}
 
-	r.confDef = mustFind(preguide.LookupDef("#GenConfig"))
+	r.confDef = mustFind(preguide.LookupDef("#PrestepServiceConfig"))
 	r.guideDef = mustFind(preguide.LookupDef("#Guide"))
 	r.commandDef = mustFind(preguide.LookupDef("#Command"))
 	r.commandFileDef = mustFind(preguide.LookupDef("#CommandFile"))
@@ -208,8 +209,8 @@ func (r *runner) loadSchemas() {
 }
 
 // loadConfig loads the configuration that drives the gen command. This
-// configuration is described by the genConfig type, which is maintained
-// as the #GenConfig CUE definition.
+// configuration is described by the PrestepServiceConfig type, which is
+// maintained as the #PrestepServiceConfig CUE definition.
 func (r *runner) loadConfig() {
 	if len(r.genCmd.fConfigs) == 0 {
 		return

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -190,7 +190,7 @@ import "list"
 #Upload:      #Guide.#Upload
 #UploadFile:  #Guide.#UploadFile
 
-#GenConfig: [string]: #PrestepConfig
+#PrestepServiceConfig: [string]: #PrestepConfig
 
 #PrestepConfig: {
 	Endpoint: string

--- a/internal/types/genconfig.go
+++ b/internal/types/genconfig.go
@@ -6,19 +6,22 @@ import (
 	"net/url"
 )
 
-// genConfig defines a mapping between the prestep pkg (which is essentially the
+// PrestepServiceConfig defines a mapping between the prestep pkg (which is essentially the
 // unique identifier for a prestep) and config for that prestep. For example,
 // github.com/play-with-go/gitea will map to an endpoint that explains where that
 // prestep can be "found". The Networks value represents a (non-production) config
 // that describes which Docker networks the request should be made within.
-type GenConfig map[string]*PrestepConfig
+type PrestepServiceConfig map[string]*ServiceConfig
 
-type PrestepConfig struct {
+// ServiceConfig defines a URL endpoint where a prestep can be accessed. It
+// also defines optional Docker networks to join when this service is accessed
+// by preguide in a development mode.
+type ServiceConfig struct {
 	Endpoint *url.URL
 	Networks []string
 }
 
-func (p *PrestepConfig) UnmarshalJSON(b []byte) error {
+func (p *ServiceConfig) UnmarshalJSON(b []byte) error {
 	var v struct {
 		Endpoint string
 		Networks []string

--- a/preguide.cue
+++ b/preguide.cue
@@ -104,7 +104,7 @@ import "list"
 #Upload:      #Guide.#Upload
 #UploadFile:  #Guide.#UploadFile
 
-#GenConfig: [string]: #PrestepConfig
+#PrestepServiceConfig: [string]: #PrestepConfig
 
 #PrestepConfig: {
 	Endpoint: string


### PR DESCRIPTION
Because this config type can be used outside of preguide, specifically
in the controller.