### PR TITLE
Add a Name field to both #Terminal and step-related input types

### DIFF
--- a/gencmd.go
+++ b/gencmd.go
@@ -398,7 +398,7 @@ func (r *runner) validateAndLoadsSteps(g *guide) {
 	for _, tp := range termPositions {
 		n := tp.name
 		t := intGuide.Terminals[n]
-		g.Terminals = append(g.Terminals, newTerminal(n, t))
+		g.Terminals = append(g.Terminals, t)
 	}
 
 	if len(intGuide.Steps) > 0 {
@@ -446,22 +446,22 @@ func (r *runner) validateAndLoadsSteps(g *guide) {
 			var s step
 			switch is := v.(type) {
 			case *types.Command:
-				s, err = commandStepFromCommand(stepName, is)
+				s, err = commandStepFromCommand(is)
 				check(err, "failed to parse #Command from step %v: %v", stepName, err)
 			case *types.CommandFile:
 				if !filepath.IsAbs(is.Path) {
 					is.Path = filepath.Join(g.dir, is.Path)
 				}
-				s, err = commandStepFromCommandFile(stepName, is)
+				s, err = commandStepFromCommandFile(is)
 				check(err, "failed to parse #CommandFile from step %v: %v", stepName, err)
 			case *types.Upload:
-				s, err = uploadStepFromUpload(stepName, is)
+				s, err = uploadStepFromUpload(is)
 				check(err, "failed to parse #Upload from step %v: %v", stepName, err)
 			case *types.UploadFile:
 				if !filepath.IsAbs(is.Path) {
 					is.Path = filepath.Join(g.dir, is.Path)
 				}
-				s, err = uploadStepFromUploadFile(stepName, is)
+				s, err = uploadStepFromUploadFile(is)
 				check(err, "failed to parse #UploadFile from step %v: %v", stepName, err)
 			}
 			ls, ok := g.Langs[code]

--- a/guide.go
+++ b/guide.go
@@ -35,7 +35,7 @@ type guide struct {
 
 	Langs map[types.LangCode]*langSteps
 
-	Terminals []*terminal
+	Terminals []*types.Terminal
 
 	instance    *cue.Instance
 	outinstance *cue.Instance
@@ -54,22 +54,6 @@ type guide struct {
 // TODO drop this when we support multiple terminals
 func (g *guide) Image() string {
 	return g.Terminals[0].Image
-}
-
-// Embed *types.Terminal once we have a solution to cuelang.org/issue/376
-type terminal struct {
-	Name  string
-	Image string
-}
-
-func newTerminal(name string, t *types.Terminal) *terminal {
-	res := &terminal{
-		Name: name,
-	}
-	if t != nil {
-		res.Image = t.Image
-	}
-	return res
 }
 
 // Embed *types.Prestep once we have a solution to cuelang.org/issue/376

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -101,6 +101,7 @@ import "list"
 	#Step: (#Command | #CommandFile | #Upload | #UploadFile ) & _#stepCommon
 
 	_#stepCommon: {
+		Name:     string
 		StepType: #StepType
 		Terminal: string
 		...
@@ -134,6 +135,7 @@ import "list"
 
 	#Terminal: {
 		// Image is the Docker image that will be used for the terminal session
+		Name:  string
 		Image: string
 	}
 
@@ -146,10 +148,12 @@ import "list"
 
 	Steps: [string]: [#Language]: #Step
 
-	// TODO: remove post upgrade to latest CUE? Because at that point
-	// the defaulting in #TerminalName will work
-	Steps: [string]: en: {
+	Steps: [name=string]: [#Language]: {
+		// TODO: remove post upgrade to latest CUE? Because at that point
+		// the defaulting in #TerminalName will work
 		Terminal: *#TerminalNames[0] | string
+
+		Name: name
 	}
 
 	// TODO: remove post upgrade to latest CUE? Because at that point
@@ -159,6 +163,10 @@ import "list"
 
 	// Terminals defines the required remote VMs for a given guide
 	Terminals: [string]: #Terminal
+
+	Terminals: [name=string]: {
+		Name: name
+	}
 
 	Defs: [string]: _
 }

--- a/internal/types/guide.go
+++ b/internal/types/guide.go
@@ -24,6 +24,7 @@ type Guide struct {
 }
 
 type Terminal struct {
+	Name  string
 	Image string
 }
 
@@ -97,6 +98,7 @@ type Step interface {
 type Command struct {
 	StepTypeVal StepType `json:"StepType"`
 	Terminal    string
+	Name        string
 	Source      string
 }
 
@@ -109,6 +111,7 @@ func (c *Command) StepType() StepType {
 type CommandFile struct {
 	StepTypeVal StepType `json:"StepType"`
 	Terminal    string
+	Name        string
 	Path        string
 }
 
@@ -121,6 +124,7 @@ func (c *CommandFile) StepType() StepType {
 type Upload struct {
 	StepTypeVal StepType `json:"StepType"`
 	Terminal    string
+	Name        string
 	Target      string
 	Source      string
 }
@@ -134,6 +138,7 @@ func (c *Upload) StepType() StepType {
 type UploadFile struct {
 	StepTypeVal StepType `json:"StepType"`
 	Terminal    string
+	Name        string
 	Target      string
 	Path        string
 }

--- a/preguide.cue
+++ b/preguide.cue
@@ -15,6 +15,7 @@ import "list"
 	#Step: (#Command | #CommandFile | #Upload | #UploadFile ) & _#stepCommon
 
 	_#stepCommon: {
+		Name:     string
 		StepType: #StepType
 		Terminal: string
 		...
@@ -48,6 +49,7 @@ import "list"
 
 	#Terminal: {
 		// Image is the Docker image that will be used for the terminal session
+		Name:  string
 		Image: string
 	}
 
@@ -60,10 +62,12 @@ import "list"
 
 	Steps: [string]: [#Language]: #Step
 
-	// TODO: remove post upgrade to latest CUE? Because at that point
-	// the defaulting in #TerminalName will work
-	Steps: [string]: en: {
+	Steps: [name=string]: [#Language]: {
+		// TODO: remove post upgrade to latest CUE? Because at that point
+		// the defaulting in #TerminalName will work
 		Terminal: *#TerminalNames[0] | string
+
+		Name: name
 	}
 
 	// TODO: remove post upgrade to latest CUE? Because at that point
@@ -73,6 +77,10 @@ import "list"
 
 	// Terminals defines the required remote VMs for a given guide
 	Terminals: [string]: #Terminal
+
+	Terminals: [name=string]: {
+		Name: name
+	}
 
 	Defs: [string]: _
 }

--- a/step.go
+++ b/step.go
@@ -124,14 +124,14 @@ type commandStmt struct {
 // commandStepFromCommand takes a string value that is a sequence of shell
 // statements and returns a commandStep with the individual parsed statements,
 // or an error in case s cannot be parsed
-func commandStepFromCommand(name string, s *types.Command) (*commandStep, error) {
+func commandStepFromCommand(s *types.Command) (*commandStep, error) {
 	r := strings.NewReader(s.Source)
 	f, err := syntax.NewParser().Parse(r, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse command string %q: %v", s, err)
 	}
 	res := newCommandStep(commandStep{
-		Name:     name,
+		Name:     s.Name,
 		Terminal: s.Terminal,
 	})
 	return commadStepFromSyntaxFile(res, f)
@@ -140,7 +140,7 @@ func commandStepFromCommand(name string, s *types.Command) (*commandStep, error)
 // commandStepFromCommandFile takes a path to a file that contains a sequence of shell
 // statements and returns a commandStep with the individual parsed statements,
 // or an error in case path cannot be read or parsed
-func commandStepFromCommandFile(name string, s *types.CommandFile) (*commandStep, error) {
+func commandStepFromCommandFile(s *types.CommandFile) (*commandStep, error) {
 	byts, err := ioutil.ReadFile(s.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %v: %v", s.Path, err)
@@ -151,7 +151,7 @@ func commandStepFromCommandFile(name string, s *types.CommandFile) (*commandStep
 		return nil, fmt.Errorf("failed to parse commands from %v: %v", s.Path, err)
 	}
 	res := newCommandStep(commandStep{
-		Name:     name,
+		Name:     s.Name,
 		Terminal: s.Terminal,
 	})
 	return commadStepFromSyntaxFile(res, f)
@@ -266,22 +266,22 @@ func (u *uploadStep) setorder(i int) {
 	u.Order = i
 }
 
-func uploadStepFromUpload(name string, u *types.Upload) (*uploadStep, error) {
+func uploadStepFromUpload(u *types.Upload) (*uploadStep, error) {
 	res := newUploadStep(uploadStep{
-		Name:   name,
+		Name:   u.Name,
 		Source: u.Source,
 		Target: u.Target,
 	})
 	return res, nil
 }
 
-func uploadStepFromUploadFile(name string, u *types.UploadFile) (*uploadStep, error) {
+func uploadStepFromUploadFile(u *types.UploadFile) (*uploadStep, error) {
 	byts, err := ioutil.ReadFile(u.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %v: %v", u.Path, err)
 	}
 	res := newUploadStep(uploadStep{
-		Name:   name,
+		Name:   u.Name,
 		Source: string(byts),
 		Target: u.Target,
 	})


### PR DESCRIPTION
Use nifty defaulting based on the key that defines a terminal/step in
order to automatically name the terminal/step.