### PR TITLE
Add support for multiple scenarios

### DIFF
--- a/cmd/preguide/guide.go
+++ b/cmd/preguide/guide.go
@@ -34,6 +34,7 @@ type guide struct {
 	// Embed guideStructure once we have a solution to cuelang.org/issue/376
 	Presteps  []*guidePrestep
 	Terminals []*types.Terminal
+	Scenarios []*types.Scenario
 	Networks  []string
 	Env       []string
 
@@ -56,13 +57,20 @@ type guide struct {
 type guideStructure struct {
 	Presteps  []*types.Prestep
 	Terminals []*types.Terminal
+	Scenarios []*types.Scenario
 	Networks  []string
 	Env       []string
 }
 
 // TODO drop this when we support multiple terminals
 func (g *guide) Image() string {
-	return g.Terminals[0].Image
+	if got := len(g.Terminals[0].Scenarios); got != 1 {
+		panic(fmt.Errorf("expected just 1 scenario, saw %v", got))
+	}
+	for _, v := range g.Terminals[0].Scenarios {
+		return v.Image
+	}
+	panic("should not be here")
 }
 
 // Embed *types.Prestep once we have a solution to cuelang.org/issue/376

--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -50,8 +50,13 @@ package steps
 
 import "github.com/play-with-go/preguide"
 
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
 Terminals: term1: preguide.#Guide.#Terminal & {
-       Image: "this_will_never_be_used"
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
 Steps: step0: en: preguide.#Command & { Source: """
@@ -163,7 +168,12 @@ EOD
 Terminals: [
   {
     "Name": "term1",
-    "Image": "this_will_never_be_used"
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
   }
 ]
 $ mkdir nooutput

--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -57,8 +57,13 @@ Presteps: [preguide.#Prestep & {
 	Package: "github.com/blah"
 }]
 
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
 Terminals: term1: preguide.#Guide.#Terminal & {
-       Image: "this_will_never_be_used"
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
 Steps: step1: en: preguide.#Command & {Source: """
@@ -80,7 +85,12 @@ The answer is: {{.GREETING}}!
 Terminals: [
   {
     "Name": "term1",
-    "Image": "this_will_never_be_used"
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
   }
 ]
 Presteps: [
@@ -105,8 +115,13 @@ package out
 		Version: "file"
 	}]
 	Terminals: [{
-		Name:  "term1"
-		Image: "this_will_never_be_used"
+		Name:        "term1"
+		Description: "The main terminal"
+		Scenarios: {
+			go115: {
+				Image: "this_will_never_be_used"
+			}
+		}
 	}]
 	Langs: {
 		en: {
@@ -144,7 +159,12 @@ The answer is: Hello, world!!
 Terminals: [
   {
     "Name": "term1",
-    "Image": "this_will_never_be_used"
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
   }
 ]
 Presteps: [

--- a/cmd/preguide/testdata/out_refs.txt
+++ b/cmd/preguide/testdata/out_refs.txt
@@ -31,8 +31,13 @@ package guide
 
 import "github.com/play-with-go/preguide"
 
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
 Terminals: term1: preguide.#Guide.#Terminal & {
-       Image: "this_will_never_be_used"
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
 Defs: world: "world"

--- a/cmd/preguide/testdata/prestep.txt
+++ b/cmd/preguide/testdata/prestep.txt
@@ -96,8 +96,13 @@ Presteps: [preguide.#Prestep & {
 	Args: ["Hello, world!"]
 }]
 
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
 Terminals: term1: preguide.#Guide.#Terminal & {
-       Image: "this_will_never_be_used"
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
 Steps: step1: en: preguide.#Command & {Source: """
@@ -119,7 +124,12 @@ The answer is: {{.GREETING}}!
 Terminals: [
   {
     "Name": "term1",
-    "Image": "this_will_never_be_used"
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
   }
 ]
 Presteps: [
@@ -150,7 +160,12 @@ The answer is: !
 Terminals: [
   {
     "Name": "term1",
-    "Image": "this_will_never_be_used"
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
   }
 ]
 Presteps: [
@@ -276,8 +291,13 @@ prestep: {
 		Args: ["Hello, world!"]
 	}]
 	Terminals: [{
-		Name:  "term1"
-		Image: "this_will_never_be_used"
+		Name:        "term1"
+		Description: "The main terminal"
+		Scenarios: {
+			go115: {
+				Image: "this_will_never_be_used"
+			}
+		}
 	}]
 }
 

--- a/cmd/preguide/testdata/prestep_file.txt
+++ b/cmd/preguide/testdata/prestep_file.txt
@@ -36,8 +36,13 @@ Presteps: [preguide.#Prestep & {
 	Package: "github.com/blah"
 }]
 
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
 Terminals: term1: preguide.#Guide.#Terminal & {
-       Image: "this_will_never_be_used"
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
 Steps: step1: en: preguide.#Command & {Source: """
@@ -59,7 +64,12 @@ The answer is: {{.GREETING}}!
 Terminals: [
   {
     "Name": "term1",
-    "Image": "this_will_never_be_used"
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
   }
 ]
 Presteps: [

--- a/cmd/preguide/testdata/raw.txt
+++ b/cmd/preguide/testdata/raw.txt
@@ -27,10 +27,15 @@ preguide.#Guide
 Env: ["A=B"]
 
 Terminals: term1: preguide.#Guide.#Terminal & {
-       Image: "this_will_never_be_used"
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
-Steps: step1: en: preguide.#Command & { Source: """
+Scenarios: go115: {
+	Description: "Go 1.15"
+}
+
+Steps: step1: en: preguide.#Command & {Source: """
 echo -n "Hello, world!"
 """}
 -- raw/stdout --
@@ -40,8 +45,13 @@ package out
 	Networks: []
 	Env: ["A=B"]
 	Terminals: [{
-		Name:  "term1"
-		Image: "this_will_never_be_used"
+		Name:        "term1"
+		Description: "The main terminal"
+		Scenarios: {
+			go115: {
+				Image: "this_will_never_be_used"
+			}
+		}
 	}]
 	Langs: {
 		en: {

--- a/cmd/preguide/testdata/sanitise.txt
+++ b/cmd/preguide/testdata/sanitise.txt
@@ -28,8 +28,13 @@ package steps
 
 import "github.com/play-with-go/preguide"
 
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
 Terminals: term1: preguide.#Guide.#Terminal & {
-       Image: "this_will_never_be_used"
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
 Steps: step1: en: preguide.#Upload & { Target: "hello.go", Source: """
@@ -104,7 +109,12 @@ ok  	_/home/gopher	0.042s
 Terminals: [
   {
     "Name": "term1",
-    "Image": "this_will_never_be_used"
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
   }
 ]
 $ cat <<EOD > hello.go

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -28,8 +28,13 @@ package steps
 
 import "github.com/play-with-go/preguide"
 
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
 Terminals: term1: preguide.#Guide.#Terminal & {
-       Image: "this_will_never_be_used"
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
 Steps: step1: en: preguide.#Command & { Source: """
@@ -76,7 +81,12 @@ $ git commit -am 'Initial commit'
 Terminals: [
   {
     "Name": "term1",
-    "Image": "this_will_never_be_used"
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
   }
 ]
 $ mkdir example

--- a/internal/types/guide.go
+++ b/internal/types/guide.go
@@ -20,13 +20,24 @@ type Guide struct {
 	Presteps  []*Prestep
 	Steps     map[string]LangSteps
 	Terminals map[string]*Terminal
+	Scenarios map[string]*Scenario
 	Defs      map[string]interface{}
 	Networks  []string
 	Env       []string
 }
 
+type Scenario struct {
+	Name        string
+	Description string
+}
+
 type Terminal struct {
-	Name  string
+	Name        string
+	Description string
+	Scenarios   map[string]*TerminalScenario
+}
+
+type TerminalScenario struct {
 	Image string
 }
 

--- a/out/out.cue
+++ b/out/out.cue
@@ -43,8 +43,18 @@ _#stepCommon: {
 	Stmts: [...#Stmt]
 }
 
+#Scenario: {
+	Name:        string
+	Description: string
+}
+
 #Terminal: {
-	Name:  string
+	Name:        string
+	Description: string
+	Scenarios: [string]: #TerminalScenario
+}
+
+#TerminalScenario: {
 	Image: string
 }
 
@@ -68,5 +78,6 @@ _#stepCommon: {
 // structure of a guide.
 #GuideStructure: {
 	Terminals: [...#Terminal]
+	Scenarios: [...#Scenario]
 	Presteps: [...#Prestep]
 }

--- a/preguide.cue
+++ b/preguide.cue
@@ -48,19 +48,21 @@ import "list"
 	}
 
 	#Terminal: {
-		// Image is the Docker image that will be used for the terminal session
-		Name:  string
+		Name:        string
+		Description: string
+		Scenarios: [string]: #TerminalScenario
+	}
+
+	#TerminalScenario: {
 		Image: string
 	}
 
 	// Networks is the list of docker networks to connect to when running
-	// this guide. Defaults to the list of networks specified for presteps
-	// (once we have a solution for cuelang.org/issues/473)
+	// this guide.
 	Networks: [...string]
 
 	// Env is the environment to pass to docker containers when running
-	// this guide. Defaults to the list of networks specified for presteps
-	// (once we have a solution for cuelang.org/issues/473)
+	// this guide.
 	Env: [...string]
 
 	Presteps: [...#Prestep]
@@ -80,10 +82,23 @@ import "list"
 		Name: name
 	}
 
+	// Scenarios define the various images under which this guide will be
+	// run
+	Scenarios: [string]: #Scenario
+	Scenarios: [name=string]: {
+		Name: name
+	}
+
+	_#ScenarioName: or([ for name, _ in Scenarios {name}])
+
+	for scenario, _ in Scenarios for terminal, _ in Terminals {
+		Terminals: "\(terminal)": Scenarios: "\(scenario)": #TerminalScenario
+	}
+
 	// TODO: remove post upgrade to latest CUE? Because at that point
 	// the use of or() will work, which will give a better error message
 	#TerminalNames: [ for k, _ in Terminals {k}]
-	#ok: true & and([ for s in Steps {list.Contains(#TerminalNames, s.en.Terminal)}])
+	#ok: true & and([ for s in Steps for l in s {list.Contains(#TerminalNames, l.Terminal)}])
 
 	// Terminals defines the required remote VMs for a given guide
 	Terminals: [string]: #Terminal
@@ -93,6 +108,11 @@ import "list"
 	}
 
 	Defs: [string]: _
+}
+
+#Scenario: {
+	Name:        string
+	Description: string
 }
 
 #Prestep: {
@@ -139,3 +159,14 @@ import "list"
 	// this prestep.
 	Env: [...string]
 }
+
+// Post upgrade to latest CUE we have a number of things to change/test, with /
+// reference to https://gist.github.com/myitcv/399ed50f792b49ae7224ee5cb3e504fa#file-304b02e-cue
+//
+// 1. Move to the use of #TerminalName (probably hidden) as a type for a terminal's
+// name in _#stepCommon
+// 2. Try and move to the advanced definition of Steps: [string]: [lang] to be the
+// disjunction of #Step or [scenario]: #Step
+// 3. Ensure that a step's name can be defaulted for this advanced definition (i.e.
+// that if a step is specified at the language level its name defaults, but also
+// if it is specified at the scenario level)


### PR DESCRIPTION
Scenarios are variations on a guide just as language translations are.
At the finest level of granularity, steps can be defined per language
per scenario. At the highest level they can be defined per language.

In a later iteration of this work, we will support either (at the moment
we only support per language, which implies for all scenarios).