### PR TITLE
cmd/preguide: base64 encode target filepath

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -462,6 +462,7 @@ func (gc *genCmd) validateAndLoadsSteps(g *guide) {
 				s, err = commandStepFromCommandFile(is)
 				check(err, "failed to parse #CommandFile from step %v: %v", stepName, err)
 			case *types.Upload:
+				// TODO: when we support non-Unix terminals,
 				s, err = uploadStepFromUpload(is)
 				check(err, "failed to parse #Upload from step %v: %v", stepName, err)
 			case *types.UploadFile:

--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -130,7 +130,7 @@ Hello, world! I am a #CommandFile
 
 echo "Hello, world! I am an #Upload"
 ```
-{:data-upload-path="/scripts/somewhere.sh" data-upload-src="IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWQi" data-upload-term="term1"}
+{:data-upload-path="L3NjcmlwdHMvc29tZXdoZXJlLnNo" data-upload-src="IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWQi" data-upload-term=".term1"}
 
 # Step 4
 
@@ -138,7 +138,7 @@ echo "Hello, world! I am an #Upload"
 echo "Hello, world! I am an #UploadFile"
 
 ```
-{:data-upload-path="/scripts/step2.sh" data-upload-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWRGaWxlIgo=" data-upload-term="term1"}
+{:data-upload-path="L3NjcmlwdHMvc3RlcDIuc2g=" data-upload-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWRGaWxlIgo=" data-upload-term=".term1"}
 <script>let pageGuide="alldirectives"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- alldirectives/en.compat.markdown.golden --
 ---

--- a/cmd/preguide/testdata/sanitise.txt
+++ b/cmd/preguide/testdata/sanitise.txt
@@ -81,7 +81,7 @@ func main() {
 	fmt.Println("Hello, world!")
 }
 ```
-{:data-upload-path="hello.go" data-upload-src="cGFja2FnZSBtYWluCgppbXBvcnQgImZtdCIKCmZ1bmMgbWFpbigpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQhIikKfQ==" data-upload-term="term1"}
+{:data-upload-path="aGVsbG8uZ28=" data-upload-src="cGFja2FnZSBtYWluCgppbXBvcnQgImZtdCIKCmZ1bmMgbWFpbigpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQhIikKfQ==" data-upload-term=".term1"}
 
 # Create test file
 
@@ -97,7 +97,7 @@ func TestHello(t *testing.T) {
 	fmt.Println("Hello, world... from the test!")
 }
 ```
-{:data-upload-path="hello_test.go" data-upload-src="cGFja2FnZSBtYWluCgppbXBvcnQgKAoJImZtdCIKCSJ0ZXN0aW5nIgopCgpmdW5jIFRlc3RIZWxsbyh0ICp0ZXN0aW5nLlQpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQuLi4gZnJvbSB0aGUgdGVzdCEiKQp9" data-upload-term="term1"}
+{:data-upload-path="aGVsbG9fdGVzdC5nbw==" data-upload-src="cGFja2FnZSBtYWluCgppbXBvcnQgKAoJImZtdCIKCSJ0ZXN0aW5nIgopCgpmdW5jIFRlc3RIZWxsbyh0ICp0ZXN0aW5nLlQpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQuLi4gZnJvbSB0aGUgdGVzdCEiKQp9" data-upload-term=".term1"}
 
 # Test
 

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -76,7 +76,7 @@ Initialized empty Git repository in /home/gopher/example/.git/
 ```.md
 This is a test.
 ```
-{:data-upload-path="README.md" data-upload-src="VGhpcyBpcyBhIHRlc3Qu" data-upload-term="term1"}
+{:data-upload-path="UkVBRE1FLm1k" data-upload-src="VGhpcyBpcyBhIHRlc3Qu" data-upload-term=".term1"}
 
 ```.term1
 $ git add -A


### PR DESCRIPTION
This is a workaround for github.com/play-with-go/play-with-go/issues/44.

Whilst we are at it, remove a hard-coding use of .term1 as an output
block identifier.