### PR TITLE
cmd/preguide: support different kinds of upload renderer

### DIFF
--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -125,7 +125,7 @@ Hello, world! I am a #CommandFile
 
 # Step 3
 
-```.sh
+```sh
 #!/usr/bin/env bash
 
 echo "Hello, world! I am an #Upload"
@@ -134,7 +134,7 @@ echo "Hello, world! I am an #Upload"
 
 # Step 4
 
-```.bash
+```bash
 echo "Hello, world! I am an #UploadFile"
 
 ```
@@ -170,7 +170,7 @@ Hello, world! I am a #CommandFile
 # Step 3
 
 ```.term1
-cat <<EOD > /scripts/somewhere.sh
+cat <<'EOD' > /scripts/somewhere.sh
 #!/usr/bin/env bash
 
 echo "Hello, world! I am an #Upload"
@@ -180,7 +180,7 @@ EOD
 # Step 4
 
 ```.term1
-cat <<EOD > /scripts/step2.sh
+cat <<'EOD' > /scripts/step2.sh
 echo "Hello, world! I am an #UploadFile"
 
 EOD

--- a/cmd/preguide/testdata/raw.txt
+++ b/cmd/preguide/testdata/raw.txt
@@ -38,6 +38,13 @@ Scenarios: go115: {
 Steps: step1: en: preguide.#Command & {Source: """
 echo -n "Hello, world!"
 """}
+
+Steps: step2: en: preguide.#Upload & {
+	Target: "/home/gopher/special.sh"
+	Source: """
+echo -n "Hello, world!"
+"""
+}
 -- raw/stdout --
 package out
 
@@ -73,8 +80,20 @@ package out
 						Output:   "Hello, world!"
 					}]
 				}
+				step2: {
+					Name:     "step2"
+					StepType: 2
+					Terminal: "term1"
+					Target:   "/home/gopher/special.sh"
+					Language: "sh"
+					Renderer: {
+						RendererType: 1
+					}
+					Source: "echo -n \"Hello, world!\""
+					Order:  1
+				}
 			}
-			Hash: "d4efc23981d2701822054ce5f1b9498fe7498d32034ba12958413d7c29287cb2"
+			Hash: "49ad685197e42b0d67ae7c75791431837e5438e96d13b6023c45c3483c979ff7"
 		}
 	}
 }

--- a/cmd/preguide/testdata/renderers.txt
+++ b/cmd/preguide/testdata/renderers.txt
@@ -1,0 +1,257 @@
+# Test that we get the expected behaviour when using different types of
+# renderers for upload steps
+
+# Intial run
+preguide gen -out _output
+! stdout .+
+! stderr .+
+cmp _output/_posts/renderers.markdown renderers/en_pre.markdown.golden
+cmp renderers/out/gen_out.cue renderers/out/gen_out_pre.cue.golden
+
+# Check that we get a cache hit second time around
+preguide -debug gen -out _output
+! stdout .+
+stderr '^cache hit for en: will not re-run script$'
+cmp _output/_posts/renderers.markdown renderers/en_pre.markdown.golden
+cmp renderers/out/gen_out.cue renderers/out/gen_out_pre.cue.golden
+
+# Change the renderertype and ensure we get a cache hit but
+# different output schema
+cp renderers/steps.cue.changed renderers/steps.cue
+preguide -debug gen -out _output
+! stdout .+
+stderr '^cache hit for en: will not re-run script$'
+cmp _output/_posts/renderers.markdown renderers/en_post.markdown.golden
+cmp renderers/out/gen_out.cue renderers/out/gen_out_post.cue.golden
+
+-- renderers/en.markdown --
+---
+title: A test with all directives
+---
+# Step 1
+
+<!--step: step0 -->
+
+<!--step: step1 -->
+
+-- renderers/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Guide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Steps: step0: en: preguide.#Command & {
+	Source: """
+echo -n "Hello"
+"""
+}
+
+// Include some backtick text in the file contents to verify
+// that when uploading the file the backtick portion is not
+// expanded by bash
+Steps: step1: en: preguide.#Upload & {
+	Target:   "/home/gopher/somewhere.md"
+	Source: """
+This is some markdown `with code`
+Another line
+A third line
+"""
+}
+-- renderers/steps.cue.changed --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Guide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Steps: step0: en: preguide.#Command & {
+	Source: """
+echo -n "Hello"
+"""
+}
+
+Steps: step1: en: preguide.#Upload & {
+	Target:   "/home/gopher/somewhere.md"
+	Renderer: preguide.#RenderLineRanges & {
+		Lines: [[2,2]]
+	}
+	Source: """
+This is some markdown `with code`
+Another line
+A third line
+"""
+}
+
+-- renderers/en_pre.markdown.golden --
+---
+guide: renderers
+lang: en
+title: A test with all directives
+---
+# Step 1
+
+```.term1
+$ echo -n "Hello"
+Hello
+```
+{:data-command-src="ZWNobyAtbiAiSGVsbG8iCg=="}
+
+```md
+This is some markdown `with code`
+Another line
+A third line
+```
+{:data-upload-path="L2hvbWUvZ29waGVyL3NvbWV3aGVyZS5tZA==" data-upload-src="VGhpcyBpcyBzb21lIG1hcmtkb3duIGB3aXRoIGNvZGVgCkFub3RoZXIgbGluZQpBIHRoaXJkIGxpbmU=" data-upload-term=".term1"}
+
+<script>let pageGuide="renderers"; let pageLanguage="en"; let pageScenario="go115";</script>
+-- renderers/en_post.markdown.golden --
+---
+guide: renderers
+lang: en
+title: A test with all directives
+---
+# Step 1
+
+```.term1
+$ echo -n "Hello"
+Hello
+```
+{:data-command-src="ZWNobyAtbiAiSGVsbG8iCg=="}
+
+```md
+...
+Another line
+...
+```
+{:data-upload-path="L2hvbWUvZ29waGVyL3NvbWV3aGVyZS5tZA==" data-upload-src="VGhpcyBpcyBzb21lIG1hcmtkb3duIGB3aXRoIGNvZGVgCkFub3RoZXIgbGluZQpBIHRoaXJkIGxpbmU=" data-upload-term=".term1"}
+
+<script>let pageGuide="renderers"; let pageLanguage="en"; let pageScenario="go115";</script>
+-- renderers/out/gen_out_pre.cue.golden --
+package out
+
+{
+	Scenarios: [{
+		Name:        "go115"
+		Description: "Go 1.15"
+	}]
+	Networks: []
+	Env: []
+	Delims: ["{{", "}}"]
+	Terminals: [{
+		Name:        "term1"
+		Description: "The main terminal"
+		Scenarios: {
+			go115: {
+				Image: "this_will_never_be_used"
+			}
+		}
+	}]
+	Langs: {
+		en: {
+			Steps: {
+				step0: {
+					Name:     "step0"
+					StepType: 1
+					Terminal: "term1"
+					Order:    0
+					Stmts: [{
+						Negated:  false
+						CmdStr:   "echo -n \"Hello\""
+						ExitCode: 0
+						Output:   "Hello"
+					}]
+				}
+				step1: {
+					Name:     "step1"
+					StepType: 2
+					Terminal: "term1"
+					Target:   "/home/gopher/somewhere.md"
+					Language: "md"
+					Renderer: {
+						RendererType: 1
+					}
+					Source: """
+        This is some markdown `with code`
+        Another line
+        A third line
+        """
+					Order: 1
+				}
+			}
+			Hash: "dcd7404882aea68168134facc7b62fd6f2e0a64089ebd417843f75b3f200b560"
+		}
+	}
+}
+-- renderers/out/gen_out_post.cue.golden --
+package out
+
+{
+	Scenarios: [{
+		Name:        "go115"
+		Description: "Go 1.15"
+	}]
+	Networks: []
+	Env: []
+	Delims: ["{{", "}}"]
+	Terminals: [{
+		Name:        "term1"
+		Description: "The main terminal"
+		Scenarios: {
+			go115: {
+				Image: "this_will_never_be_used"
+			}
+		}
+	}]
+	Langs: {
+		en: {
+			Steps: {
+				step0: {
+					Name:     "step0"
+					StepType: 1
+					Terminal: "term1"
+					Order:    0
+					Stmts: [{
+						Negated:  false
+						CmdStr:   "echo -n \"Hello\""
+						ExitCode: 0
+						Output:   "Hello"
+					}]
+				}
+				step1: {
+					Name:     "step1"
+					StepType: 2
+					Terminal: "term1"
+					Target:   "/home/gopher/somewhere.md"
+					Language: "md"
+					Renderer: {
+						RendererType: 2
+						Ellipsis:     "..."
+						Lines: [[2, 2]]
+					}
+					Source: """
+        This is some markdown `with code`
+        Another line
+        A third line
+        """
+					Order: 1
+				}
+			}
+			Hash: "dcd7404882aea68168134facc7b62fd6f2e0a64089ebd417843f75b3f200b560"
+		}
+	}
+}

--- a/cmd/preguide/testdata/sanitise.txt
+++ b/cmd/preguide/testdata/sanitise.txt
@@ -72,7 +72,7 @@ title: A test with output that should be sanitised
 ---
 # Create go file
 
-```.go
+```go
 package main
 
 import "fmt"
@@ -85,7 +85,7 @@ func main() {
 
 # Create test file
 
-```.go
+```go
 package main
 
 import (

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -73,7 +73,7 @@ Initialized empty Git repository in /home/gopher/example/.git/
 ```
 {:data-command-src="bWtkaXIgZXhhbXBsZQpjZCBleGFtcGxlCmdpdCBpbml0Cg=="}
 
-```.md
+```md
 This is a test.
 ```
 {:data-upload-path="UkVBRE1FLm1k" data-upload-src="VGhpcyBpcyBhIHRlc3Qu" data-upload-term=".term1"}

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -90,6 +90,7 @@ _#stepCommon: {
 
 #UploadStep: {
 	_#stepCommon
+	Renderer: preguide.#Renderer
 	Language: string
 	Source:   string
 	Target:   string
@@ -145,12 +146,17 @@ import (
 	}
 
 	_#uploadCommon: {
+		Target: string
+
 		// The language of the content being uploaded, e.g. go
 		// This gets used on the markdown code block, hence the
 		// values supported here are a function of the markdown
 		// parse on the other end.
-		Target:   string
 		Language: *regexp.FindSubmatch("^.(.*)", path.Ext(Target))[1] | string
+
+		// Renderer defines how the upload file contents will be
+		// rendered to the user in the guide.
+		Renderer: #Renderer
 		...
 	}
 
@@ -291,6 +297,32 @@ import (
 	// Env is the environment to pass to docker containers when running
 	// this prestep.
 	Env: [...string]
+}
+
+// Renderers define what part (or whole) of an upload file should be shown (rendered)
+// to the user in the guide.
+#Renderer: (*#RenderFull | #RenderLineRanges) & _#rendererCommon
+
+#RendererType: int
+
+#RendererTypeFull:       #RendererType & 1
+#RendererTypeLineRanges: #RendererType & 2
+
+_#rendererCommon: {
+	RendererType: #RendererType
+	...
+}
+
+#RenderFull: {
+	_#rendererCommon
+	RendererType: #RendererTypeFull
+}
+
+#RenderLineRanges: {
+	_#rendererCommon
+	RendererType: #RendererTypeLineRanges
+	Ellipsis:     *"..." | string
+	Lines: [...[int, int]]
 }
 
 // Post upgrade to latest CUE we have a number of things to change/test, with /

--- a/out/out.cue
+++ b/out/out.cue
@@ -74,6 +74,7 @@ _#stepCommon: {
 
 #UploadStep: {
 	_#stepCommon
+	Renderer: preguide.#Renderer
 	Language: string
 	Source:   string
 	Target:   string

--- a/preguide.cue
+++ b/preguide.cue
@@ -26,12 +26,17 @@ import (
 	}
 
 	_#uploadCommon: {
+		Target: string
+
 		// The language of the content being uploaded, e.g. go
 		// This gets used on the markdown code block, hence the
 		// values supported here are a function of the markdown
 		// parse on the other end.
-		Target:   string
 		Language: *regexp.FindSubmatch("^.(.*)", path.Ext(Target))[1] | string
+
+		// Renderer defines how the upload file contents will be
+		// rendered to the user in the guide.
+		Renderer: #Renderer
 		...
 	}
 
@@ -172,6 +177,32 @@ import (
 	// Env is the environment to pass to docker containers when running
 	// this prestep.
 	Env: [...string]
+}
+
+// Renderers define what part (or whole) of an upload file should be shown (rendered)
+// to the user in the guide.
+#Renderer: (*#RenderFull | #RenderLineRanges) & _#rendererCommon
+
+#RendererType: int
+
+#RendererTypeFull:       #RendererType & 1
+#RendererTypeLineRanges: #RendererType & 2
+
+_#rendererCommon: {
+	RendererType: #RendererType
+	...
+}
+
+#RenderFull: {
+	_#rendererCommon
+	RendererType: #RendererTypeFull
+}
+
+#RenderLineRanges: {
+	_#rendererCommon
+	RendererType: #RendererTypeLineRanges
+	Ellipsis:     *"..." | string
+	Lines: [...[int, int]]
 }
 
 // Post upgrade to latest CUE we have a number of things to change/test, with /


### PR DESCRIPTION
This allows us to show parts of a file instead of the entire thing,
which is particularly useful when making a series of edits to a file.