### PR TITLE
cmd/preguide: refactor and fix various sanitiser bits

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -855,9 +855,14 @@ func (gc *genCmd) runBashFile(g *guide, ls *langSteps) {
 				walk = walk[len(fence):]
 				stmt.Output = slurp(fence)
 				if !*gc.fRaw {
-					for _, s := range append(stmt.sanitisers, g.sanitiseVars) {
-						stmt.Output = s(stmt.Output)
+					// Sanitise variables first in order that "custom" sanitisers can, if required
+					// match against variable templates.
+					o := stmt.Output
+					o, varNames := g.sanitiseVars(o)
+					for _, s := range stmt.sanitisers {
+						o = s(varNames, o)
 					}
+					stmt.Output = o
 				}
 				exitCodeStr := slurp([]byte("\n"))
 				stmt.ExitCode, err = strconv.Atoi(exitCodeStr)

--- a/cmd/preguide/guide.go
+++ b/cmd/preguide/guide.go
@@ -198,7 +198,7 @@ func (r *runner) writeGuideOutput(g *guide) {
 			// Build a map of the variable names to escape
 			escVarMap := make(map[string]string)
 			for v := range g.varMap {
-				escVarMap[v] = "{% raw %}{{." + v + "}}{% endraw %}"
+				escVarMap[v] = "{% raw %}" + g.Delims[0] + "." + v + g.Delims[1] + "{% endraw %}"
 			}
 			t := template.New("{{.ENV}} normalising and escaping")
 			t.Option("missingkey=error")
@@ -244,9 +244,12 @@ func mustJSONMarshalIndent(i interface{}) []byte {
 
 }
 
-func (g *guide) sanitiseVars(s string) string {
+func (g *guide) sanitiseVars(s string) (string, []string) {
+	var tmpls []string
 	for name, val := range g.varMap {
-		s = strings.ReplaceAll(s, val, "{{."+name+"}}")
+		repl := g.Delims[0] + "." + name + g.Delims[1]
+		tmpls = append(tmpls, repl)
+		s = strings.ReplaceAll(s, val, repl)
 	}
-	return s
+	return s, tmpls
 }

--- a/cmd/preguide/sanitise_gitcommit.go
+++ b/cmd/preguide/sanitise_gitcommit.go
@@ -6,10 +6,10 @@ import (
 )
 
 var (
-	gitCommitFirstLine = regexp.MustCompile(`^(\[master \(root-commit\) )[0-9a-f]+(\] .*)$`)
+	gitCommitFirstLine = regexp.MustCompile(`^(\[[[:alpha:]]+ \(root-commit\) )[0-9a-f]+(\] .*)$`)
 )
 
-func sanitiseGitCommit(s string) string {
+func sanitiseGitCommit(varNames []string, s string) string {
 	lines := strings.SplitN(s, "\n", 2)
 	lines[0] = gitCommitFirstLine.ReplaceAllString(lines[0], "${1}abcd123${2}")
 	return strings.Join(lines, "\n")

--- a/cmd/preguide/sanitise_gotest.go
+++ b/cmd/preguide/sanitise_gotest.go
@@ -16,7 +16,7 @@ var (
 	goTestFailSummary    = regexp.MustCompile(`^((FAIL|ok  )\t.+\t)` + goTestTestTime + `$`)
 )
 
-func sanitiseGoTest(s string) string {
+func sanitiseGoTest(varNames []string, s string) string {
 	lines := strings.Split(s, "\n")
 	for i := range lines {
 		lines[i] = goTestPassRunHeading.ReplaceAllString(lines[i], fmt.Sprintf("${1}%v)", goTestMagicTime))

--- a/cmd/preguide/sanitisers.go
+++ b/cmd/preguide/sanitisers.go
@@ -6,7 +6,7 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
-type sanitiser func(string) string
+type sanitiser func(varNames []string, output string) string
 
 type sanitiserMatcher struct {
 	printer *syntax.Printer

--- a/cmd/preguide/sanitisers_test.go
+++ b/cmd/preguide/sanitisers_test.go
@@ -53,7 +53,7 @@ FAIL
 	}}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("TestSanitiseGoTest_%v", i), func(t *testing.T) {
-			got := sanitiseGoTest(tc.in)
+			got := sanitiseGoTest(nil, tc.in)
 			if got != tc.want {
 				t.Fatalf("failed to get sanitised output: %v", cmp.Diff(got, tc.want))
 			}


### PR DESCRIPTION
* Always apply env var replacement before other sanitisers
* Refactor a sanitiser to take a list of var names from env var
  replacement
* Consistently use a guide's delims instead of assuming {{,}}
* Make the git commit sanitiser not assume master