### PR TITLE
cmd/preguide: enforce absolute target upload paths (for now)

### DIFF
--- a/cmd/preguide/filepath_unix.go
+++ b/cmd/preguide/filepath_unix.go
@@ -1,0 +1,9 @@
+// +build linux
+
+package main
+
+import "path/filepath"
+
+func isAbsolute(p string) bool {
+	return filepath.IsAbs(p)
+}

--- a/cmd/preguide/testdata/sanitise.txt
+++ b/cmd/preguide/testdata/sanitise.txt
@@ -1,7 +1,6 @@
 # Test that we get the expected output when a step involves
 # output that should sanitised
 
-# Intial run
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
@@ -37,7 +36,7 @@ Terminals: term1: preguide.#Guide.#Terminal & {
 	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
-Steps: step1: en: preguide.#Upload & { Target: "hello.go", Source: """
+Steps: step1: en: preguide.#Upload & { Target: "/home/gopher/hello.go", Source: """
 package main
 
 import "fmt"
@@ -47,7 +46,7 @@ func main() {
 }
 """ }
 
-Steps: step2: en: preguide.#Upload & { Target: "hello_test.go", Source: """
+Steps: step2: en: preguide.#Upload & { Target: "/home/gopher/hello_test.go", Source: """
 package main
 
 import (
@@ -81,7 +80,7 @@ func main() {
 	fmt.Println("Hello, world!")
 }
 ```
-{:data-upload-path="aGVsbG8uZ28=" data-upload-src="cGFja2FnZSBtYWluCgppbXBvcnQgImZtdCIKCmZ1bmMgbWFpbigpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQhIikKfQ==" data-upload-term=".term1"}
+{:data-upload-path="L2hvbWUvZ29waGVyL2hlbGxvLmdv" data-upload-src="cGFja2FnZSBtYWluCgppbXBvcnQgImZtdCIKCmZ1bmMgbWFpbigpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQhIikKfQ==" data-upload-term=".term1"}
 
 # Create test file
 
@@ -97,7 +96,7 @@ func TestHello(t *testing.T) {
 	fmt.Println("Hello, world... from the test!")
 }
 ```
-{:data-upload-path="aGVsbG9fdGVzdC5nbw==" data-upload-src="cGFja2FnZSBtYWluCgppbXBvcnQgKAoJImZtdCIKCSJ0ZXN0aW5nIgopCgpmdW5jIFRlc3RIZWxsbyh0ICp0ZXN0aW5nLlQpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQuLi4gZnJvbSB0aGUgdGVzdCEiKQp9" data-upload-term=".term1"}
+{:data-upload-path="L2hvbWUvZ29waGVyL2hlbGxvX3Rlc3QuZ28=" data-upload-src="cGFja2FnZSBtYWluCgppbXBvcnQgKAoJImZtdCIKCSJ0ZXN0aW5nIgopCgpmdW5jIFRlc3RIZWxsbyh0ICp0ZXN0aW5nLlQpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQuLi4gZnJvbSB0aGUgdGVzdCEiKQp9" data-upload-term=".term1"}
 
 # Test
 
@@ -121,7 +120,7 @@ Terminals: [
     }
   }
 ]
-$ cat <<EOD > hello.go
+$ cat <<EOD > /home/gopher/hello.go
 package main
 
 import "fmt"
@@ -130,7 +129,7 @@ func main() {
 	fmt.Println("Hello, world!")
 }
 EOD
-$ cat <<EOD > hello_test.go
+$ cat <<EOD > /home/gopher/hello_test.go
 package main
 
 import (

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -46,7 +46,7 @@ git init
 }
 
 Steps: step2: en: preguide.#Upload & {
-	Target: "README.md"
+	Target: "/home/gopher/example/README.md"
 	Source: """
 This is a test.
 """
@@ -76,7 +76,7 @@ Initialized empty Git repository in /home/gopher/example/.git/
 ```md
 This is a test.
 ```
-{:data-upload-path="UkVBRE1FLm1k" data-upload-src="VGhpcyBpcyBhIHRlc3Qu" data-upload-term=".term1"}
+{:data-upload-path="L2hvbWUvZ29waGVyL2V4YW1wbGUvUkVBRE1FLm1k" data-upload-src="VGhpcyBpcyBhIHRlc3Qu" data-upload-term=".term1"}
 
 ```.term1
 $ git add -A
@@ -103,7 +103,7 @@ $ mkdir example
 $ cd example
 $ git init
 Initialized empty Git repository in /home/gopher/example/.git/
-$ cat <<EOD > README.md
+$ cat <<EOD > /home/gopher/example/README.md
 This is a test.
 EOD
 $ git add -A


### PR DESCRIPTION
This check (for now) assumes a Unix environment.