### PR TITLE
cmd/preguide: add -runargs flag

### DIFF
--- a/cmd/preguide/testdata/help.txt
+++ b/cmd/preguide/testdata/help.txt
@@ -76,5 +76,7 @@ usage: preguide gen
 	        generate raw output for steps
 	  -run string
 	        regexp that describes which guides within dir to validate and run (default ".")
+	  -runargs value
+	        additional arguments to pass to the script that runs for a terminal. Format -run=$terminalName=args...; can appear multiple times
 	  -skipcache
 	        whether to skip any output cache checking

--- a/cmd/preguide/testdata/runargs.txt
+++ b/cmd/preguide/testdata/runargs.txt
@@ -1,0 +1,75 @@
+# Test that -runargs flag works
+
+# Bad args
+! preguide gen -out _output -runargs 'term6=-e GREETING=hello'
+! stdout .+
+stderr 'bad argument passed to -runargs'
+
+# Good args
+preguide gen -out _output -runargs 'term1=-e GREETING=hello'
+cmp guide/out/gen_out.cue guide/out/gen_out.cue.golden
+
+-- guide/en.markdown --
+---
+title: A test with all directives
+---
+# Step 1
+
+<!--step: step1 -->
+-- guide/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Guide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Steps: step1: en: preguide.#Command & {Source: """
+echo -n "The answer is: $GREETING"
+"""}
+-- guide/out/gen_out.cue.golden --
+package out
+
+{
+	Scenarios: [{
+		Name:        "go115"
+		Description: "Go 1.15"
+	}]
+	Networks: []
+	Env: []
+	Delims: ["{{", "}}"]
+	Terminals: [{
+		Name:        "term1"
+		Description: "The main terminal"
+		Scenarios: {
+			go115: {
+				Image: "this_will_never_be_used"
+			}
+		}
+	}]
+	Langs: {
+		en: {
+			Steps: {
+				step1: {
+					Name:     "step1"
+					StepType: 1
+					Terminal: "term1"
+					Order:    0
+					Stmts: [{
+						Negated:  false
+						CmdStr:   "echo -n \"The answer is: $GREETING\""
+						ExitCode: 0
+						Output:   "The answer is: hello"
+					}]
+				}
+			}
+			Hash: "f84141eeea2e0ecdc7fb79678069e372693bc399b127d32b5c6d58d9bcdbe2cb"
+		}
+	}
+}


### PR DESCRIPTION
-runargs allows the caller to pass arbitrary flags to docker when the
guide is "run", i.e. when the bash script that represents the file is
run. These are specified per terminal (despite us only supporting one
terminal for now) in order that different flags can be passed to each
(there are scenarios where unconditionally passing the same flags to all
terminals would be wrong, so we leave this to the caller).

Note these flags are in no way validated; any errors will be reported
back by the docker process and "bulbbled up".