### PR TITLE
cmd/preguide: do not hardcode _posts as output dir

### DIFF
--- a/cmd/preguide/guide.go
+++ b/cmd/preguide/guide.go
@@ -101,7 +101,7 @@ func (r *runner) writeGuideOutput(g *guide) {
 
 	var err error
 
-	postsDir := filepath.Join(g.target, "_posts")
+	postsDir := g.target
 	err = os.MkdirAll(postsDir, 0777)
 	check(err, "failed to os.MkdirAll %v: %v", postsDir, err)
 

--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -4,26 +4,26 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/alldirectives.markdown alldirectives/en.markdown.golden
+cmp _output/alldirectives.markdown alldirectives/en.markdown.golden
 cmp alldirectives/en_log.txt alldirectives/en_log.txt.golden
 
 # Check that we get a cache hit
 preguide -debug gen -out _output
 ! stdout .+
 stderr '^cache hit for en: will not re-run script$'
-cmp _output/_posts/alldirectives.markdown alldirectives/en.markdown.golden
+cmp _output/alldirectives.markdown alldirectives/en.markdown.golden
 cmp alldirectives/en_log.txt alldirectives/en_log.txt.golden
 
 # Verify that when skipping the cache we get the same output
 preguide gen -skipcache -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/alldirectives.markdown alldirectives/en.markdown.golden
+cmp _output/alldirectives.markdown alldirectives/en.markdown.golden
 cmp alldirectives/en_log.txt alldirectives/en_log.txt.golden
 
 # Verify that -compat works as expected
 preguide gen -compat -out _output
-cmp _output/_posts/alldirectives.markdown alldirectives/en.compat.markdown.golden
+cmp _output/alldirectives.markdown alldirectives/en.compat.markdown.golden
 cmp alldirectives/en_log.txt alldirectives/en_log.txt.golden
 
 -- alldirectives/en.markdown --

--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -21,14 +21,14 @@ envsubst conf.cue
 preguide gen -config conf.cue -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/env_template.markdown env_template/en.markdown.golden
+cmp _output/env_template.markdown env_template/en.markdown.golden
 cmp env_template/en_log.txt env_template/en_log.txt.golden
 
 # Run with -raw
 preguide gen -raw -config conf.cue -out _output
 cmp stdout env_template/raw.cue.golden
 ! stderr .+
-cmp _output/_posts/env_template.markdown env_template/en.markdown.raw.golden
+cmp _output/env_template.markdown env_template/en.markdown.raw.golden
 cmp env_template/en_log.txt env_template/en_log.txt.raw.golden
 
 -- prestep.txt --

--- a/cmd/preguide/testdata/no_directives.txt
+++ b/cmd/preguide/testdata/no_directives.txt
@@ -4,7 +4,7 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/nodirectives.md nodirectives/en.md.golden
+cmp _output/nodirectives.md nodirectives/en.md.golden
 
 -- nodirectives/en.md --
 ---

--- a/cmd/preguide/testdata/out_refs.txt
+++ b/cmd/preguide/testdata/out_refs.txt
@@ -3,7 +3,7 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/defs.md defs/en.md.golden
+cmp _output/defs.md defs/en.md.golden
 
 -- defs/en.md --
 ---

--- a/cmd/preguide/testdata/prestep.txt
+++ b/cmd/preguide/testdata/prestep.txt
@@ -19,7 +19,7 @@ cp version.1 version
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/prestep.markdown prestep/en.markdown.golden
+cmp _output/prestep.markdown prestep/en.markdown.golden
 cmp prestep/en_log.txt prestep/en_log.txt.golden
 cmp gen_guide_structures.cue gen_guide_structures.cue.golden
 
@@ -27,7 +27,7 @@ cmp gen_guide_structures.cue gen_guide_structures.cue.golden
 preguide -debug gen -out _output
 ! stdout .+
 stderr '^cache hit for en: will not re-run script$'
-cmp _output/_posts/prestep.markdown prestep/en.markdown.golden
+cmp _output/prestep.markdown prestep/en.markdown.golden
 cmp prestep/en_log.txt prestep/en_log.txt.golden
 
 # Verify that changing the prestep causes a new output
@@ -35,7 +35,7 @@ cp version.2 version
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/prestep.markdown prestep/en.markdown.other.golden
+cmp _output/prestep.markdown prestep/en.markdown.other.golden
 cmp prestep/en_log.txt prestep/en_log.txt.other.golden
 
 # Now do docker tests by running the server in a docker container.
@@ -47,7 +47,7 @@ cp conf.docker.cue conf.cue
 preguide gen -docker $PREGUIDE_IMAGE_OVERRIDE -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/prestep.markdown prestep/en.markdown.golden
+cmp _output/prestep.markdown prestep/en.markdown.golden
 cmp prestep/en_log.txt prestep/en_log.txt.golden
 
 -- go.mod --

--- a/cmd/preguide/testdata/prestep_file.txt
+++ b/cmd/preguide/testdata/prestep_file.txt
@@ -10,7 +10,7 @@ envsubst conf.cue
 preguide gen -config conf.cue -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/prestep_text.markdown prestep_text/en.markdown.golden
+cmp _output/prestep_text.markdown prestep_text/en.markdown.golden
 cmp prestep_text/en_log.txt prestep_text/en_log.txt.golden
 
 -- prestep.txt --

--- a/cmd/preguide/testdata/refs.txt
+++ b/cmd/preguide/testdata/refs.txt
@@ -3,7 +3,7 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/defs.md defs/en.md.golden
+cmp _output/defs.md defs/en.md.golden
 
 -- defs/en.md --
 ---

--- a/cmd/preguide/testdata/renderers.txt
+++ b/cmd/preguide/testdata/renderers.txt
@@ -5,14 +5,14 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/renderers.markdown renderers/en_pre.markdown.golden
+cmp _output/renderers.markdown renderers/en_pre.markdown.golden
 cmp renderers/out/gen_out.cue renderers/out/gen_out_pre.cue.golden
 
 # Check that we get a cache hit second time around
 preguide -debug gen -out _output
 ! stdout .+
 stderr '^cache hit for en: will not re-run script$'
-cmp _output/_posts/renderers.markdown renderers/en_pre.markdown.golden
+cmp _output/renderers.markdown renderers/en_pre.markdown.golden
 cmp renderers/out/gen_out.cue renderers/out/gen_out_pre.cue.golden
 
 # Change the renderertype and ensure we get a cache hit but
@@ -21,7 +21,7 @@ cp renderers/steps.cue.changed renderers/steps.cue
 preguide -debug gen -out _output
 ! stdout .+
 stderr '^cache hit for en: will not re-run script$'
-cmp _output/_posts/renderers.markdown renderers/en_post.markdown.golden
+cmp _output/renderers.markdown renderers/en_post.markdown.golden
 cmp renderers/out/gen_out.cue renderers/out/gen_out_post.cue.golden
 
 -- renderers/en.markdown --

--- a/cmd/preguide/testdata/run.txt
+++ b/cmd/preguide/testdata/run.txt
@@ -1,50 +1,50 @@
 # Verify that -run works as expected
 
 # Tidy up (all, regardless of whether they exist)
-rm _output/_posts/run1.markdown
-rm _output/_posts/run2.markdown
+rm _output/run1.markdown
+rm _output/run2.markdown
 
 # Run only 1
 preguide gen -run 1 -out _output
-exists _output/_posts/run1.markdown
-! exists _output/_posts/run2.markdown
+exists _output/run1.markdown
+! exists _output/run2.markdown
 
 # Tidy up (all, regardless of whether they exist)
-rm _output/_posts/run1.markdown
-rm _output/_posts/run2.markdown
+rm _output/run1.markdown
+rm _output/run2.markdown
 
 # Run only 2
 preguide gen -run 2 -out _output
-! exists _output/_posts/run1.markdown
-exists _output/_posts/run2.markdown
+! exists _output/run1.markdown
+exists _output/run2.markdown
 
 # Tidy up (all, regardless of whether they exist)
-rm _output/_posts/run1.markdown
-rm _output/_posts/run2.markdown
+rm _output/run1.markdown
+rm _output/run2.markdown
 
 # Run all
 preguide gen -run . -out _output
-exists _output/_posts/run1.markdown
-exists _output/_posts/run2.markdown
+exists _output/run1.markdown
+exists _output/run2.markdown
 
 # Tidy up (all, regardless of whether they exist)
-rm _output/_posts/run1.markdown
-rm _output/_posts/run2.markdown
+rm _output/run1.markdown
+rm _output/run2.markdown
 
 # Run only 1 via PREGUIDE_RUN
 env PREGUIDE_RUN=1
 preguide gen -out _output
-exists _output/_posts/run1.markdown
-! exists _output/_posts/run2.markdown
+exists _output/run1.markdown
+! exists _output/run2.markdown
 
 # Tidy up (all, regardless of whether they exist)
-rm _output/_posts/run1.markdown
-rm _output/_posts/run2.markdown
+rm _output/run1.markdown
+rm _output/run2.markdown
 
 # Run all by overriding preguide via -run
 preguide gen -run . -out _output
-exists _output/_posts/run1.markdown
-exists _output/_posts/run2.markdown
+exists _output/run1.markdown
+exists _output/run2.markdown
 
 
 -- run1/en.markdown --

--- a/cmd/preguide/testdata/sanitise.txt
+++ b/cmd/preguide/testdata/sanitise.txt
@@ -4,7 +4,7 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/sanitise.markdown sanitise/en.markdown.golden
+cmp _output/sanitise.markdown sanitise/en.markdown.golden
 cmp sanitise/en_log.txt sanitise/en_log.txt.golden
 
 -- sanitise/en.markdown --

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -5,7 +5,7 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/_posts/sanitise.markdown sanitise/en.markdown.golden
+cmp _output/sanitise.markdown sanitise/en.markdown.golden
 cmp sanitise/en_log.txt sanitise/en_log.txt.golden
 
 -- go.mod --


### PR DESCRIPTION
This can easily be specified by the caller.

In preparation for -mode flag, which will allow jekyll and github as
options (default jekyll).