### PR TITLE
cmd/preguide: add -mode flag to control output

### DIFF
--- a/cmd/preguide/testdata/github.txt
+++ b/cmd/preguide/testdata/github.txt
@@ -1,0 +1,82 @@
+# Test that we get the expected output when using -mode github
+
+# Check that we cannot use -mode github with -compat
+! preguide gen -out _output -mode github -compat
+! stdout .+
+stderr '-compat flag is not valid when output mode is github'
+
+# Check that we get the expected output
+preguide gen -out _output -mode github
+! stdout .+
+! stderr .+
+cmp _output/myguide.markdown myguide/en.markdown.golden
+
+-- myguide/en.markdown --
+---
+title: A test with all directives
+---
+# Step 1
+
+<!--step: step1 -->
+
+# Step 2
+
+<!--step: step2 -->
+-- myguide/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Guide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Steps: step0: en: preguide.#Command & {
+	Source: """
+mkdir nooutput
+"""
+}
+
+Steps: step1: en: preguide.#Command & {
+	Source: """
+echo "Hello, world! I am a #Command"
+touch blah
+! false
+ls
+"""
+}
+
+Steps: step2: en: preguide.#Upload & {
+	Target:   "/scripts/somewhere.bash"
+	Source: """
+#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"
+"""
+}
+
+-- myguide/en.markdown.golden --
+# Step 1
+
+```
+$ echo "Hello, world! I am a #Command"
+Hello, world! I am a #Command
+$ touch blah
+$ false
+$ ls
+blah
+nooutput
+```
+
+# Step 2
+
+```bash
+#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"
+```

--- a/cmd/preguide/testdata/help.txt
+++ b/cmd/preguide/testdata/help.txt
@@ -66,6 +66,8 @@ usage: preguide gen
 	        run prestep requests in a docker container configured by the arguments passed to this flag
 	  -image string
 	        the image to use instead of the guide-specified image
+	  -mode value
+	        the output mode. Valid values are: jekyll, github (default jekyll)
 	  -out string
 	        the target directory for generation
 	  -package string


### PR DESCRIPTION
Whilst we are developing play-with-go.dev, Jekyll will be a predominant
output type/format. However, GitHub is also a valid target.