### PR TITLE
cmd/preguide: write out package as file

### DIFF
--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -111,47 +111,45 @@ The answer is: {{.GREETING}}!
 -- myguide/raw.cue.golden --
 package out
 
-{
-	Scenarios: [{
-		Name:        "go115"
-		Description: "Go 1.15"
-	}]
-	Networks: []
-	Env: []
-	Presteps: [{
-		Path:    "/"
-		Package: "github.com/blah"
-		Version: "file"
-		Variables: ["GREETING"]
-	}]
-	Delims: ["{{", "}}"]
-	Terminals: [{
-		Name:        "term1"
-		Description: "The main terminal"
-		Scenarios: {
-			go115: {
-				Image: "this_will_never_be_used"
+Scenarios: [{
+	Name:        "go115"
+	Description: "Go 1.15"
+}]
+Networks: []
+Env: []
+Presteps: [{
+	Path:    "/"
+	Package: "github.com/blah"
+	Version: "file"
+	Variables: ["GREETING"]
+}]
+Delims: ["{{", "}}"]
+Terminals: [{
+	Name:        "term1"
+	Description: "The main terminal"
+	Scenarios: {
+		go115: {
+			Image: "this_will_never_be_used"
+		}
+	}
+}]
+Langs: {
+	en: {
+		Steps: {
+			step1: {
+				Name:     "step1"
+				StepType: 1
+				Terminal: "term1"
+				Order:    0
+				Stmts: [{
+					Negated:  false
+					CmdStr:   "echo -n \"The answer is: {{.GREETING}}!\""
+					ExitCode: 0
+					Output:   "The answer is: Hello, world!!"
+				}]
 			}
 		}
-	}]
-	Langs: {
-		en: {
-			Steps: {
-				step1: {
-					Name:     "step1"
-					StepType: 1
-					Terminal: "term1"
-					Order:    0
-					Stmts: [{
-						Negated:  false
-						CmdStr:   "echo -n \"The answer is: {{.GREETING}}!\""
-						ExitCode: 0
-						Output:   "The answer is: Hello, world!!"
-					}]
-				}
-			}
-			Hash: "6b2274e96ac076207bf49a061a0862b88150be2cb809c40af6dbc702cb31ca76"
-		}
+		Hash: "6b2274e96ac076207bf49a061a0862b88150be2cb809c40af6dbc702cb31ca76"
 	}
 }
 -- myguide/en.markdown.raw.golden --

--- a/cmd/preguide/testdata/raw.txt
+++ b/cmd/preguide/testdata/raw.txt
@@ -48,52 +48,50 @@ echo -n "Hello, world!"
 -- myguide/stdout --
 package out
 
-{
-	Scenarios: [{
-		Name:        "go115"
-		Description: "Go 1.15"
-	}]
-	Networks: []
-	Env: ["A=B"]
-	Delims: ["{{", "}}"]
-	Terminals: [{
-		Name:        "term1"
-		Description: "The main terminal"
-		Scenarios: {
-			go115: {
-				Image: "this_will_never_be_used"
+Scenarios: [{
+	Name:        "go115"
+	Description: "Go 1.15"
+}]
+Networks: []
+Env: ["A=B"]
+Delims: ["{{", "}}"]
+Terminals: [{
+	Name:        "term1"
+	Description: "The main terminal"
+	Scenarios: {
+		go115: {
+			Image: "this_will_never_be_used"
+		}
+	}
+}]
+Langs: {
+	en: {
+		Steps: {
+			step1: {
+				Name:     "step1"
+				StepType: 1
+				Terminal: "term1"
+				Order:    0
+				Stmts: [{
+					Negated:  false
+					CmdStr:   "echo -n \"Hello, world!\""
+					ExitCode: 0
+					Output:   "Hello, world!"
+				}]
+			}
+			step2: {
+				Name:     "step2"
+				StepType: 2
+				Terminal: "term1"
+				Target:   "/home/gopher/special.sh"
+				Language: "sh"
+				Renderer: {
+					RendererType: 1
+				}
+				Source: "echo -n \"Hello, world!\""
+				Order:  1
 			}
 		}
-	}]
-	Langs: {
-		en: {
-			Steps: {
-				step1: {
-					Name:     "step1"
-					StepType: 1
-					Terminal: "term1"
-					Order:    0
-					Stmts: [{
-						Negated:  false
-						CmdStr:   "echo -n \"Hello, world!\""
-						ExitCode: 0
-						Output:   "Hello, world!"
-					}]
-				}
-				step2: {
-					Name:     "step2"
-					StepType: 2
-					Terminal: "term1"
-					Target:   "/home/gopher/special.sh"
-					Language: "sh"
-					Renderer: {
-						RendererType: 1
-					}
-					Source: "echo -n \"Hello, world!\""
-					Order:  1
-				}
-			}
-			Hash: "49ad685197e42b0d67ae7c75791431837e5438e96d13b6023c45c3483c979ff7"
-		}
+		Hash: "49ad685197e42b0d67ae7c75791431837e5438e96d13b6023c45c3483c979ff7"
 	}
 }

--- a/cmd/preguide/testdata/renderers.txt
+++ b/cmd/preguide/testdata/renderers.txt
@@ -144,114 +144,110 @@ Another line
 -- myguide/out/gen_out_pre.cue.golden --
 package out
 
-{
-	Scenarios: [{
-		Name:        "go115"
-		Description: "Go 1.15"
-	}]
-	Networks: []
-	Env: []
-	Delims: ["{{", "}}"]
-	Terminals: [{
-		Name:        "term1"
-		Description: "The main terminal"
-		Scenarios: {
-			go115: {
-				Image: "this_will_never_be_used"
-			}
+Scenarios: [{
+	Name:        "go115"
+	Description: "Go 1.15"
+}]
+Networks: []
+Env: []
+Delims: ["{{", "}}"]
+Terminals: [{
+	Name:        "term1"
+	Description: "The main terminal"
+	Scenarios: {
+		go115: {
+			Image: "this_will_never_be_used"
 		}
-	}]
-	Langs: {
-		en: {
-			Steps: {
-				step0: {
-					Name:     "step0"
-					StepType: 1
-					Terminal: "term1"
-					Order:    0
-					Stmts: [{
-						Negated:  false
-						CmdStr:   "echo -n \"Hello\""
-						ExitCode: 0
-						Output:   "Hello"
-					}]
+	}
+}]
+Langs: {
+	en: {
+		Steps: {
+			step0: {
+				Name:     "step0"
+				StepType: 1
+				Terminal: "term1"
+				Order:    0
+				Stmts: [{
+					Negated:  false
+					CmdStr:   "echo -n \"Hello\""
+					ExitCode: 0
+					Output:   "Hello"
+				}]
+			}
+			step1: {
+				Name:     "step1"
+				StepType: 2
+				Terminal: "term1"
+				Target:   "/home/gopher/somewhere.md"
+				Language: "md"
+				Renderer: {
+					RendererType: 1
 				}
-				step1: {
-					Name:     "step1"
-					StepType: 2
-					Terminal: "term1"
-					Target:   "/home/gopher/somewhere.md"
-					Language: "md"
-					Renderer: {
-						RendererType: 1
-					}
-					Source: """
+				Source: """
         This is some markdown `with code`
         Another line
         A third line
         """
-					Order: 1
-				}
+				Order: 1
 			}
-			Hash: "dcd7404882aea68168134facc7b62fd6f2e0a64089ebd417843f75b3f200b560"
 		}
+		Hash: "dcd7404882aea68168134facc7b62fd6f2e0a64089ebd417843f75b3f200b560"
 	}
 }
 -- myguide/out/gen_out_post.cue.golden --
 package out
 
-{
-	Scenarios: [{
-		Name:        "go115"
-		Description: "Go 1.15"
-	}]
-	Networks: []
-	Env: []
-	Delims: ["{{", "}}"]
-	Terminals: [{
-		Name:        "term1"
-		Description: "The main terminal"
-		Scenarios: {
-			go115: {
-				Image: "this_will_never_be_used"
-			}
+Scenarios: [{
+	Name:        "go115"
+	Description: "Go 1.15"
+}]
+Networks: []
+Env: []
+Delims: ["{{", "}}"]
+Terminals: [{
+	Name:        "term1"
+	Description: "The main terminal"
+	Scenarios: {
+		go115: {
+			Image: "this_will_never_be_used"
 		}
-	}]
-	Langs: {
-		en: {
-			Steps: {
-				step0: {
-					Name:     "step0"
-					StepType: 1
-					Terminal: "term1"
-					Order:    0
-					Stmts: [{
-						Negated:  false
-						CmdStr:   "echo -n \"Hello\""
-						ExitCode: 0
-						Output:   "Hello"
-					}]
+	}
+}]
+Langs: {
+	en: {
+		Steps: {
+			step0: {
+				Name:     "step0"
+				StepType: 1
+				Terminal: "term1"
+				Order:    0
+				Stmts: [{
+					Negated:  false
+					CmdStr:   "echo -n \"Hello\""
+					ExitCode: 0
+					Output:   "Hello"
+				}]
+			}
+			step1: {
+				Name:     "step1"
+				StepType: 2
+				Terminal: "term1"
+				Target:   "/home/gopher/somewhere.md"
+				Language: "md"
+				Renderer: {
+					RendererType: 2
+					Ellipsis:     "..."
+					Lines: [[2, 2]]
 				}
-				step1: {
-					Name:     "step1"
-					StepType: 2
-					Terminal: "term1"
-					Target:   "/home/gopher/somewhere.md"
-					Language: "md"
-					Renderer: {
-						RendererType: 2
-						Ellipsis:     "..."
-						Lines: [[2, 2]]
-					}
-					Source: """
+				Source: """
         This is some markdown `with code`
         Another line
         A third line
         """
-					Order: 1
-				}
+				Order: 1
 			}
-			Hash: "dcd7404882aea68168134facc7b62fd6f2e0a64089ebd417843f75b3f200b560"
 		}
+		Hash: "dcd7404882aea68168134facc7b62fd6f2e0a64089ebd417843f75b3f200b560"
 	}
 }

--- a/cmd/preguide/testdata/runargs.txt
+++ b/cmd/preguide/testdata/runargs.txt
@@ -36,40 +36,38 @@ echo -n "The answer is: $GREETING"
 -- myguide/out/gen_out.cue.golden --
 package out
 
-{
-	Scenarios: [{
-		Name:        "go115"
-		Description: "Go 1.15"
-	}]
-	Networks: []
-	Env: []
-	Delims: ["{{", "}}"]
-	Terminals: [{
-		Name:        "term1"
-		Description: "The main terminal"
-		Scenarios: {
-			go115: {
-				Image: "this_will_never_be_used"
+Scenarios: [{
+	Name:        "go115"
+	Description: "Go 1.15"
+}]
+Networks: []
+Env: []
+Delims: ["{{", "}}"]
+Terminals: [{
+	Name:        "term1"
+	Description: "The main terminal"
+	Scenarios: {
+		go115: {
+			Image: "this_will_never_be_used"
+		}
+	}
+}]
+Langs: {
+	en: {
+		Steps: {
+			step1: {
+				Name:     "step1"
+				StepType: 1
+				Terminal: "term1"
+				Order:    0
+				Stmts: [{
+					Negated:  false
+					CmdStr:   "echo -n \"The answer is: $GREETING\""
+					ExitCode: 0
+					Output:   "The answer is: hello"
+				}]
 			}
 		}
-	}]
-	Langs: {
-		en: {
-			Steps: {
-				step1: {
-					Name:     "step1"
-					StepType: 1
-					Terminal: "term1"
-					Order:    0
-					Stmts: [{
-						Negated:  false
-						CmdStr:   "echo -n \"The answer is: $GREETING\""
-						ExitCode: 0
-						Output:   "The answer is: hello"
-					}]
-				}
-			}
-			Hash: "f84141eeea2e0ecdc7fb79678069e372693bc399b127d32b5c6d58d9bcdbe2cb"
-		}
+		Hash: "f84141eeea2e0ecdc7fb79678069e372693bc399b127d32b5c6d58d9bcdbe2cb"
 	}
 }


### PR DESCRIPTION
Currently we fudge the writing of the out package, effectively writing a
struct value's syntax wrapped with a package declaration.

Instead, do this proplery, and dry up the code to create a helper
function to do just this (it's also used elsewhere).