### PR TITLE
cmd/preguide: fix docker invocation logic

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -1183,7 +1183,8 @@ func (gc *genCmd) doRequest(method string, endpoint string, conf *preguide.Servi
 		}
 		body = &w
 	}
-	if *gc.fDocker {
+	// We need Docker if we need to connect to networks
+	if len(conf.Networks) > 0 && !*gc.fDocker {
 		cmd := gc.newDockerRunner(conf.Networks,
 			// Don't leave this container around
 			"--rm",
@@ -1194,9 +1195,6 @@ func (gc *genCmd) doRequest(method string, endpoint string, conf *preguide.Servi
 		)
 		for _, e := range conf.Env {
 			cmd.Args = append(cmd.Args, "-e", e)
-		}
-		if v, ok := os.LookupEnv("TESTSCRIPT_COMMAND"); ok {
-			cmd.Args = append(cmd.Args, "-e", "TESTSCRIPT_COMMAND="+v)
 		}
 		gc.addSelfArgs(cmd)
 		// Now add the arguments to "ourselves"

--- a/cmd/preguide/testdata/prestep.txt
+++ b/cmd/preguide/testdata/prestep.txt
@@ -44,7 +44,7 @@ cmp myguide/en_log.txt myguide/en_log.txt.other.golden
 exec docker run --rm --network-alias server --network $PRESTEP_NETWORK --volume=$WORK:/workdir --volume=$PRESTEP_SERVER_BINARY:/workdir/server --workdir=/workdir --entrypoint=/workdir/server $PREGUIDE_IMAGE_OVERRIDE :8080 &
 cp version.1 version
 cp conf.docker.cue conf.cue
-preguide gen -docker -out _output
+preguide gen -out _output
 ! stdout .+
 ! stderr .+
 cmp _output/myguide.markdown myguide/en.markdown.golden


### PR DESCRIPTION
We should only invoke via docker when required. We defined "requried" as
meaning there is some networks config.