### PR TITLE
cmd/preguide: defined TrimmedOutput on an out #Stmt

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -1004,6 +1004,7 @@ func (gc *genCmd) runBashFile(g *guide, ls *langSteps) {
 					}
 					stmt.Output = o
 				}
+				stmt.TrimmedOutput = trimTrailingNewline(stmt.Output)
 				exitCodeStr := slurp([]byte("\n"))
 				stmt.ExitCode, err = strconv.Atoi(exitCodeStr)
 				check(err, "failed to parse exit code from %q at position %v in output: %v\n%s", exitCodeStr, len(out)-len(walk)-len(exitCodeStr)-1, err, out)

--- a/cmd/preguide/step.go
+++ b/cmd/preguide/step.go
@@ -120,11 +120,12 @@ func (c *commandStep) setorder(i int) {
 }
 
 type commandStmt struct {
-	Negated     bool
-	CmdStr      string
-	ExitCode    int
-	Output      string
-	outputFence string
+	Negated       bool
+	CmdStr        string
+	ExitCode      int
+	Output        string
+	TrimmedOutput string
+	outputFence   string
 
 	sanitisers []sanitisers.Sanitiser
 }
@@ -253,7 +254,16 @@ func (c *commandStep) setOutputFrom(s step) {
 	for i, s := range oc.Stmts {
 		c.Stmts[i].ExitCode = s.ExitCode
 		c.Stmts[i].Output = s.Output
+		c.Stmts[i].TrimmedOutput = s.TrimmedOutput
 	}
+}
+
+func trimTrailingNewline(s string) string {
+	trimmed := s
+	if len(trimmed) > 0 && trimmed[len(trimmed)-1] == '\n' {
+		trimmed = trimmed[:len(trimmed)-1]
+	}
+	return trimmed
 }
 
 type uploadStep struct {

--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -138,10 +138,11 @@ Langs: {
 		Steps: {
 			step1: {
 				Stmts: [{
-					Output:   "The answer is: Hello, world!!"
-					ExitCode: 0
-					CmdStr:   "echo -n \"The answer is: {{.GREETING}}!\""
-					Negated:  false
+					TrimmedOutput: "The answer is: Hello, world!!"
+					Output:        "The answer is: Hello, world!!"
+					ExitCode:      0
+					CmdStr:        "echo -n \"The answer is: {{.GREETING}}!\""
+					Negated:       false
 				}]
 				Order:    0
 				Terminal: "term1"

--- a/cmd/preguide/testdata/out_refs.txt
+++ b/cmd/preguide/testdata/out_refs.txt
@@ -23,8 +23,11 @@ Here are some commands:
 
 <!--step: step1 -->
 
-Here we talk about the second of those commands,
-`<!--outref: cmd_false -->`.
+Here we talk about the second of those commands, `<!--outref: cmd_false -->`.
+
+We also present the output of `<!--outref: echo_out-->`.
+
+We also present the trimmed output of `<!--outref: trimmed_echo_out-->`.
 
 -- myguide/guide.cue --
 package guide
@@ -52,7 +55,9 @@ ls
 package out
 
 Defs: {
-	cmd_false: Langs.en.Steps.step1.Stmts[2].CmdStr
+	echo_out:         Langs.en.Steps.step1.Stmts[0].Output
+	trimmed_echo_out: Langs.en.Steps.step1.Stmts[0].TrimmedOutput
+	cmd_false:        Langs.en.Steps.step1.Stmts[2].CmdStr
 }
 -- myguide/en.md.golden --
 ---
@@ -82,7 +87,11 @@ blah
 ```
 {:data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISIKdG91Y2ggYmxhaApmYWxzZQpscwo="}
 
-Here we talk about the second of those commands,
-`false`.
+Here we talk about the second of those commands, `false`.
+
+We also present the output of `Hello, world!
+`.
+
+We also present the trimmed output of `Hello, world!`.
 
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>

--- a/cmd/preguide/testdata/raw.txt
+++ b/cmd/preguide/testdata/raw.txt
@@ -83,10 +83,11 @@ Langs: {
 			}
 			step1: {
 				Stmts: [{
-					Output:   "Hello, world!"
-					ExitCode: 0
-					CmdStr:   "echo -n \"Hello, world!\""
-					Negated:  false
+					TrimmedOutput: "Hello, world!"
+					Output:        "Hello, world!"
+					ExitCode:      0
+					CmdStr:        "echo -n \"Hello, world!\""
+					Negated:       false
 				}]
 				Order:    0
 				Terminal: "term1"

--- a/cmd/preguide/testdata/renderer_diff.txt
+++ b/cmd/preguide/testdata/renderer_diff.txt
@@ -143,10 +143,11 @@ Langs: {
 			}
 			step0: {
 				Stmts: [{
-					Output:   "Hello"
-					ExitCode: 0
-					CmdStr:   "echo -n \"Hello\""
-					Negated:  false
+					TrimmedOutput: "Hello"
+					Output:        "Hello"
+					ExitCode:      0
+					CmdStr:        "echo -n \"Hello\""
+					Negated:       false
 				}]
 				Order:    0
 				Terminal: "term1"

--- a/cmd/preguide/testdata/renderers.txt
+++ b/cmd/preguide/testdata/renderers.txt
@@ -175,10 +175,11 @@ Langs: {
 			}
 			step0: {
 				Stmts: [{
-					Output:   "Hello"
-					ExitCode: 0
-					CmdStr:   "echo -n \"Hello\""
-					Negated:  false
+					TrimmedOutput: "Hello"
+					Output:        "Hello"
+					ExitCode:      0
+					CmdStr:        "echo -n \"Hello\""
+					Negated:       false
 				}]
 				Order:    0
 				Terminal: "term1"
@@ -231,10 +232,11 @@ Langs: {
 			}
 			step0: {
 				Stmts: [{
-					Output:   "Hello"
-					ExitCode: 0
-					CmdStr:   "echo -n \"Hello\""
-					Negated:  false
+					TrimmedOutput: "Hello"
+					Output:        "Hello"
+					ExitCode:      0
+					CmdStr:        "echo -n \"Hello\""
+					Negated:       false
 				}]
 				Order:    0
 				Terminal: "term1"

--- a/cmd/preguide/testdata/runargs.txt
+++ b/cmd/preguide/testdata/runargs.txt
@@ -57,10 +57,11 @@ Langs: {
 		Steps: {
 			step1: {
 				Stmts: [{
-					Output:   "The answer is: hello"
-					ExitCode: 0
-					CmdStr:   "echo -n \"The answer is: $GREETING\""
-					Negated:  false
+					TrimmedOutput: "The answer is: hello"
+					Output:        "The answer is: hello"
+					ExitCode:      0
+					CmdStr:        "echo -n \"The answer is: $GREETING\""
+					Negated:       false
 				}]
 				Order:    0
 				Terminal: "term1"

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -71,6 +71,10 @@ _#stepCommon: {
 	CmdStr:   string
 	ExitCode: int
 	Output:   string
+
+	// TrimmedOutput is the Output from the statement
+	// with the trailing \n removed
+	TrimmedOutput: string
 }
 
 #UploadStep: {

--- a/out/out.cue
+++ b/out/out.cue
@@ -55,6 +55,10 @@ _#stepCommon: {
 	CmdStr:   string
 	ExitCode: int
 	Output:   string
+
+	// TrimmedOutput is the Output from the statement
+	// with the trailing \n removed
+	TrimmedOutput: string
 }
 
 #UploadStep: {


### PR DESCRIPTION
This is a convenience for those situations where you do not want the
trailing \n that commands include to make output line-based.