### PR TITLE
cmd/preguide: fix bug with loading of out package

### DIFF
--- a/cmd/preguide/guide.go
+++ b/cmd/preguide/guide.go
@@ -51,7 +51,6 @@ type guide struct {
 	outinstance *cue.Instance
 
 	outputGuide *guide
-	output      cue.Value
 
 	vars []string
 


### PR DESCRIPTION
We attempt to load the out package for a guide at two points. First when
considering whether we need to re-run a guide or not (the out package
contains a hash of the inputs). Second, when resolving and outref
directives.

We currently try to load the entire out package for the first load, and
ignore any load errors.

We now only try to load the generated part of the out package. We still
tolerate errors during this first load. The generated part of the out
package is valid by itself. i.e. if we are able to load it, the data
validates against the out schema etc, then that is sufficient for the
purposes of checking the hash value. On the second load we load the
entire out package, and do not tolerate any errors.