### PR TITLE
cmd/preguide: preliminary support for parallel script execution

### DIFF
--- a/cmd/preguide/cueworkarounds.go
+++ b/cmd/preguide/cueworkarounds.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"sync"
+
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/load"
+)
+
+var cueLoadMutxex sync.Mutex
+
+func cueLoadInstances(args []string, c *load.Config) []*build.Instance {
+	cueLoadMutxex.Lock()
+	defer cueLoadMutxex.Unlock()
+	return load.Instances(args, c)
+}

--- a/cmd/preguide/guide.go
+++ b/cmd/preguide/guide.go
@@ -93,7 +93,7 @@ type guidePrestep struct {
 // writeGuideOutput writes the markdown files of output for a guide
 // that result from the combination of the configuration and input
 // to a guide.
-func (gc *genCmd) writeGuideOutput(g *guide) {
+func (pdc *processDirContext) writeGuideOutput(g *guide) {
 	if len(g.mdFiles) != 1 || g.mdFiles[0].lang != "en" {
 		raise("we only support English language guides for now")
 	}
@@ -112,7 +112,7 @@ func (gc *genCmd) writeGuideOutput(g *guide) {
 		check(err, "failed to open %v for writing: %v", outFilePath, err)
 
 		// TODO: support all front-matter formats
-		switch gc.fMode {
+		switch pdc.fMode {
 		case types.ModeJekyll:
 			switch md.frontFormat {
 			case "yaml":
@@ -142,10 +142,10 @@ func (gc *genCmd) writeGuideOutput(g *guide) {
 				buf.Write(md.content[pos:d.Pos()])
 				switch d := d.(type) {
 				case *stepDirective:
-					if *gc.genCmd.fCompat {
-						steps[d.Key()].renderCompat(gc.fMode, &buf)
+					if *pdc.genCmd.fCompat {
+						steps[d.Key()].renderCompat(pdc.fMode, &buf)
 					} else {
-						steps[d.Key()].render(gc.fMode, &buf)
+						steps[d.Key()].render(pdc.fMode, &buf)
 					}
 				case *refDirective:
 					switch d.val.Kind() {
@@ -169,7 +169,7 @@ func (gc *genCmd) writeGuideOutput(g *guide) {
 			buf.Write(md.content)
 		}
 
-		switch gc.fMode {
+		switch pdc.fMode {
 		case types.ModeJekyll:
 			// Now write a simple <script> block that declares some useful variables
 			// that will be picked up by postLayout.js
@@ -205,7 +205,7 @@ func (gc *genCmd) writeGuideOutput(g *guide) {
 		//
 		// However, if there are no vars, then the substitution will have zero
 		// effect (regardless of whether there are any templates to be expanded)
-		if !*gc.genCmd.fRaw || len(g.vars) == 0 {
+		if !*pdc.genCmd.fRaw || len(g.vars) == 0 {
 			// Build a map of the variable names to escape
 			escVarMap := make(map[string]string)
 			for v := range g.varMap {
@@ -235,7 +235,7 @@ func (gc *genCmd) writeGuideOutput(g *guide) {
 }
 
 // writeLog writes a
-func (gc *genCmd) writeLog(g *guide) {
+func (pdc *processDirContext) writeLog(g *guide) {
 	for lang, ls := range g.Langs {
 		var buf bytes.Buffer
 		fmt.Fprintf(&buf, "Terminals: %s\n", mustJSONMarshalIndent(g.Terminals))
@@ -243,7 +243,7 @@ func (gc *genCmd) writeLog(g *guide) {
 			fmt.Fprintf(&buf, "Presteps: %s\n", mustJSONMarshalIndent(g.Presteps))
 		}
 		for _, step := range ls.steps {
-			step.renderLog(gc.fMode, &buf)
+			step.renderLog(pdc.fMode, &buf)
 		}
 		logFilePath := filepath.Join(g.dir, fmt.Sprintf("%v_log.txt", lang))
 		err := ioutil.WriteFile(logFilePath, buf.Bytes(), 0666)

--- a/cmd/preguide/step.go
+++ b/cmd/preguide/step.go
@@ -133,7 +133,7 @@ type commandStmt struct {
 // commandStepFromCommand takes a string value that is a sequence of shell
 // statements and returns a commandStep with the individual parsed statements,
 // or an error in case s cannot be parsed
-func (gc *genCmd) commandStepFromCommand(s *types.Command) (*commandStep, error) {
+func (pdc *processDirContext) commandStepFromCommand(s *types.Command) (*commandStep, error) {
 	r := strings.NewReader(s.Source)
 	f, err := syntax.NewParser().Parse(r, "")
 	if err != nil {
@@ -143,13 +143,13 @@ func (gc *genCmd) commandStepFromCommand(s *types.Command) (*commandStep, error)
 		Name:     s.Name,
 		Terminal: s.Terminal,
 	})
-	return gc.commadStepFromSyntaxFile(res, f)
+	return pdc.commadStepFromSyntaxFile(res, f)
 }
 
 // commandStepFromCommandFile takes a path to a file that contains a sequence of shell
 // statements and returns a commandStep with the individual parsed statements,
 // or an error in case path cannot be read or parsed
-func (gc *genCmd) commandStepFromCommandFile(s *types.CommandFile) (*commandStep, error) {
+func (pdc *processDirContext) commandStepFromCommandFile(s *types.CommandFile) (*commandStep, error) {
 	byts, err := ioutil.ReadFile(s.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %v: %v", s.Path, err)
@@ -163,13 +163,13 @@ func (gc *genCmd) commandStepFromCommandFile(s *types.CommandFile) (*commandStep
 		Name:     s.Name,
 		Terminal: s.Terminal,
 	})
-	return gc.commadStepFromSyntaxFile(res, f)
+	return pdc.commadStepFromSyntaxFile(res, f)
 }
 
 // commadStepFromSyntaxFile takes a *mvdan.cc/sh/syntax.File and returns a
 // commandStep with the individual statements, or an error in case any of the
 // statements cannot be printed as string values
-func (gc *genCmd) commadStepFromSyntaxFile(res *commandStep, f *syntax.File) (*commandStep, error) {
+func (pdc *processDirContext) commadStepFromSyntaxFile(res *commandStep, f *syntax.File) (*commandStep, error) {
 	res.StepType = StepTypeCommand
 	for i, stmt := range f.Stmts {
 		// Capture whether this statement is negated or not
@@ -179,12 +179,12 @@ func (gc *genCmd) commadStepFromSyntaxFile(res *commandStep, f *syntax.File) (*c
 		// bash script
 		stmt.Negated = false
 		var sb strings.Builder
-		if err := gc.stmtPrinter.Print(&sb, stmt); err != nil {
+		if err := pdc.stmtPrinter.Print(&sb, stmt); err != nil {
 			return res, fmt.Errorf("failed to print statement %v: %v", i, err)
 		}
 		var sanitiers []sanitisers.Sanitiser
 		for _, d := range stmtSanitisers {
-			if san := d(gc.sanitiserHelper, stmt); san != nil {
+			if san := d(pdc.sanitiserHelper, stmt); san != nil {
 				sanitiers = append(sanitiers, san)
 			}
 		}
@@ -318,7 +318,7 @@ func (u *uploadStep) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (gc *genCmd) uploadStepFromUpload(u *types.Upload) (*uploadStep, error) {
+func (pdc *processDirContext) uploadStepFromUpload(u *types.Upload) (*uploadStep, error) {
 	res := newUploadStep(uploadStep{
 		Name:     u.Name,
 		Terminal: u.Terminal,
@@ -330,7 +330,7 @@ func (gc *genCmd) uploadStepFromUpload(u *types.Upload) (*uploadStep, error) {
 	return res, nil
 }
 
-func (gc *genCmd) uploadStepFromUploadFile(u *types.UploadFile) (*uploadStep, error) {
+func (pdc *processDirContext) uploadStepFromUploadFile(u *types.UploadFile) (*uploadStep, error) {
 	byts, err := ioutil.ReadFile(u.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %v: %v", u.Path, err)

--- a/cmd/preguide/testdata/help.txt
+++ b/cmd/preguide/testdata/help.txt
@@ -72,6 +72,8 @@ usage: preguide gen
 	        the target directory for generation. If no value is specified it defaults to the input directory
 	  -package string
 	        the CUE package name to use for the generated guide structure file
+	  -parallel int
+	        allow parallel execution of preguide scripts. The value of this flag is the maximum number of scripts to run simultaneously. By default it is set to the value of GOMAXPROCS
 	  -pull string
 	        try and docker pull image if missing
 	  -raw

--- a/cmd/preguide/testdata/parallel.txt
+++ b/cmd/preguide/testdata/parallel.txt
@@ -1,0 +1,209 @@
+# Test that we get the expected output when running with -parallel 2
+
+# Intial run
+preguide gen -parallel 2 -out _output
+! stdout .+
+! stderr .+
+cmp _output/myguide1.markdown myguide1/en.markdown.golden
+cmp _output/myguide2.markdown myguide2/en.markdown.golden
+cmp myguide1/en_log.txt myguide1/en_log.txt.golden
+cmp myguide2/en_log.txt myguide2/en_log.txt.golden
+
+-- myguide1/en.markdown --
+---
+title: A test with all directives
+---
+# Step 1
+
+<!--step: step1 -->
+
+# Step 2
+
+<!--step: step2 -->
+-- myguide1/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Steps: step0: en: preguide.#Command & {
+	Source: """
+mkdir nooutput
+"""
+}
+
+Steps: step1: en: preguide.#Command & {
+	Source: """
+echo "Hello, world! I am a #Command"
+touch blah
+! false
+ls
+"""
+}
+
+Steps: step2: en: preguide.#Upload & {
+	Target:   "/scripts/somewhere.sh"
+	Source: """
+#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"
+"""
+}
+
+-- myguide2/en.markdown --
+---
+title: A test with all directives
+---
+# Step 1
+
+<!--step: step1 -->
+
+# Step 2
+
+<!--step: step2 -->
+-- myguide2/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Steps: step0: en: preguide.#Command & {
+	Source: """
+mkdir nooutput
+"""
+}
+
+Steps: step1: en: preguide.#Command & {
+	Source: """
+echo "Hello, world! I am a #Command"
+touch blah
+! false
+ls
+"""
+}
+
+Steps: step2: en: preguide.#Upload & {
+	Target:   "/scripts/somewhere.sh"
+	Source: """
+#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"
+"""
+}
+
+-- myguide1/en.markdown.golden --
+---
+guide: myguide1
+lang: en
+title: A test with all directives
+---
+# Step 1
+
+```.term1
+$ echo "Hello, world! I am a #Command"
+Hello, world! I am a #Command
+$ touch blah
+$ false
+$ ls
+blah
+nooutput
+```
+{:data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"}
+
+# Step 2
+
+<pre data-upload-path="L3NjcmlwdHM=" data-upload-src="c29tZXdoZXJlLnNo:IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWQi" data-upload-term=".term1"><code class="language-sh">#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"</code></pre>
+<script>let pageGuide="myguide1"; let pageLanguage="en"; let pageScenario="go115";</script>
+-- myguide1/en_log.txt.golden --
+Terminals: [
+  {
+    "Name": "term1",
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
+  }
+]
+$ mkdir nooutput
+$ echo "Hello, world! I am a #Command"
+Hello, world! I am a #Command
+$ touch blah
+$ false
+$ ls
+blah
+nooutput
+$ cat <<EOD > /scripts/somewhere.sh
+#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"
+EOD
+-- myguide2/en.markdown.golden --
+---
+guide: myguide2
+lang: en
+title: A test with all directives
+---
+# Step 1
+
+```.term1
+$ echo "Hello, world! I am a #Command"
+Hello, world! I am a #Command
+$ touch blah
+$ false
+$ ls
+blah
+nooutput
+```
+{:data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"}
+
+# Step 2
+
+<pre data-upload-path="L3NjcmlwdHM=" data-upload-src="c29tZXdoZXJlLnNo:IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWQi" data-upload-term=".term1"><code class="language-sh">#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"</code></pre>
+<script>let pageGuide="myguide2"; let pageLanguage="en"; let pageScenario="go115";</script>
+-- myguide2/en_log.txt.golden --
+Terminals: [
+  {
+    "Name": "term1",
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "this_will_never_be_used"
+      }
+    }
+  }
+]
+$ mkdir nooutput
+$ echo "Hello, world! I am a #Command"
+Hello, world! I am a #Command
+$ touch blah
+$ false
+$ ls
+blah
+nooutput
+$ cat <<EOD > /scripts/somewhere.sh
+#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"
+EOD


### PR DESCRIPTION
At the moment this can't be turned on because cuelang.org/go/... is not
thread-safe. Whilst we could fix that up with some mutexes here and
there, for now we simply "disable" concurrent execution of scripts.

Also tidy up a rogue panic.