### PR TITLE
cmd/preguide: drop support for -compat flag

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -104,7 +104,6 @@ type genCmd struct {
 	fOutput        *string
 	fSkipCache     *bool
 	fImageOverride *string
-	fCompat        *bool
 	fPullImage     *string
 	fDocker        *bool
 	fRaw           *bool
@@ -205,7 +204,6 @@ func newGenCmd(r *runner) *genCmd {
 		res.fOutput = fs.String("out", "", "the target directory for generation. If no value is specified it defaults to the input directory")
 		res.fSkipCache = fs.Bool("skipcache", os.Getenv("PREGUIDE_SKIP_CACHE") == "true", "whether to skip any output cache checking")
 		res.fImageOverride = fs.String("image", os.Getenv("PREGUIDE_IMAGE_OVERRIDE"), "the image to use instead of the guide-specified image")
-		res.fCompat = fs.Bool("compat", false, "render old-style PWD code blocks")
 		res.fPullImage = fs.String("pull", os.Getenv("PREGUIDE_PULL_IMAGE"), "try and docker pull image if missing")
 		res.fDocker = fs.Bool("docker", false, "internal flag: run prestep requests in a docker container")
 		res.fRaw = fs.Bool("raw", false, "generate raw output for steps")
@@ -285,10 +283,6 @@ func (gc *genCmd) run(args []string) error {
 
 	runRegex, err := regexp.Compile(*gc.fRun)
 	check(err, "failed to compile -run regex %q: %v", *gc.fRun, err)
-
-	if *gc.fCompat && gc.fMode == types.ModeGitHub {
-		return gc.usageErr("-compat flag is not valid when output mode is %v", types.ModeGitHub)
-	}
 
 	// Fallback to env-supplied config if no values supplied via -config flag
 	if len(gc.fConfigs) == 0 {

--- a/cmd/preguide/guide.go
+++ b/cmd/preguide/guide.go
@@ -142,11 +142,7 @@ func (pdc *processDirContext) writeGuideOutput(g *guide) {
 				buf.Write(md.content[pos:d.Pos()])
 				switch d := d.(type) {
 				case *stepDirective:
-					if *pdc.genCmd.fCompat {
-						steps[d.Key()].renderCompat(pdc.fMode, &buf)
-					} else {
-						steps[d.Key()].render(pdc.fMode, &buf)
-					}
+					steps[d.Key()].render(pdc.fMode, &buf)
 				case *refDirective:
 					switch d.val.Kind() {
 					case cue.StringKind:

--- a/cmd/preguide/step.go
+++ b/cmd/preguide/step.go
@@ -83,7 +83,6 @@ type step interface {
 	terminal() string
 	setorder(int)
 	render(types.Mode, io.Writer)
-	renderCompat(types.Mode, io.Writer)
 	renderLog(types.Mode, io.Writer)
 	setOutputFrom(step)
 }
@@ -225,10 +224,6 @@ func (c *commandStep) render(mode types.Mode, w io.Writer) {
 	case types.ModeJekyll:
 		fmt.Fprintf(w, "\n{:data-command-src=%q}", cmds.Bytes())
 	}
-}
-
-func (c *commandStep) renderCompat(mode types.Mode, w io.Writer) {
-	c.render(mode, w)
 }
 
 func (c *commandStep) renderLog(mode types.Mode, w io.Writer) {
@@ -374,13 +369,6 @@ func base64Encode(s string) string {
 	targetDirEnv.Write([]byte(s))
 	targetDirEnv.Close()
 	return buf.String()
-}
-
-func (u *uploadStep) renderCompat(mode types.Mode, w io.Writer) {
-	fmt.Fprintf(w, "```.%v\n", u.Terminal)
-	source := strings.ReplaceAll(u.Source, "\t", "        ")
-	fmt.Fprintf(w, "cat <<'EOD' > %v\n%s\nEOD\n", u.Target, source)
-	fmt.Fprintf(w, "```")
 }
 
 func (u *uploadStep) renderLog(mode types.Mode, w io.Writer) {

--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -21,11 +21,6 @@ preguide gen -skipcache -out _output
 cmp _output/myguide.markdown myguide/en.markdown.golden
 cmp myguide/en_log.txt myguide/en_log.txt.golden
 
-# Verify that -compat works as expected
-preguide gen -compat -out _output
-cmp _output/myguide.markdown myguide/en.compat.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
-
 -- myguide/en.markdown --
 ---
 title: A test with all directives
@@ -133,52 +128,6 @@ echo "Hello, world! I am an #Upload"</code></pre>
 
 <pre data-upload-path="L3NjcmlwdHM=" data-upload-src="c3RlcDIuc2g=:ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWRGaWxlIgo=" data-upload-term=".term1"><code class="language-bash">echo "Hello, world! I am an #UploadFile"
 </code></pre>
-<script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en.compat.markdown.golden --
----
-guide: myguide
-lang: en
-title: A test with all directives
----
-# Step 1
-
-```.term1
-$ echo "Hello, world! I am a #Command"
-Hello, world! I am a #Command
-$ touch blah
-$ false
-$ ls
-blah
-nooutput
-```
-{:data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"}
-
-# Step 2
-
-```.term1
-$ echo "Hello, world! I am a #CommandFile"
-Hello, world! I am a #CommandFile
-```
-{:data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmRGaWxlIgo="}
-
-# Step 3
-
-```.term1
-cat <<'EOD' > /scripts/somewhere.sh
-#!/usr/bin/env bash
-
-echo "Hello, world! I am an #Upload"
-EOD
-```
-
-# Step 4
-
-```.term1
-cat <<'EOD' > /scripts/step2.sh
-echo "Hello, world! I am an #UploadFile"
-
-EOD
-```
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/en_log.txt.golden --
 Terminals: [

--- a/cmd/preguide/testdata/github.txt
+++ b/cmd/preguide/testdata/github.txt
@@ -1,10 +1,5 @@
 # Test that we get the expected output when using -mode github
 
-# Check that we cannot use -mode github with -compat
-! preguide gen -out _output -mode github -compat myguide
-! stdout .+
-stderr '-compat flag is not valid when output mode is github'
-
 # Check that we get the expected output
 preguide gen -mode github myguide
 ! stdout .+

--- a/cmd/preguide/testdata/help.txt
+++ b/cmd/preguide/testdata/help.txt
@@ -54,8 +54,6 @@ preguide defines the following flags:
 -- gen_command_help.txt --
 usage: preguide gen
 
-	  -compat
-	        render old-style PWD code blocks
 	  -config value
 	        CUE-style configuration input; can appear multiple times. See 'cue help inputs'
 	  -debugcache


### PR DESCRIPTION
No longer required. Makes supporting output and trimmedoutput directives
in the next PR simpler.