### PR TITLE
cmd/preguide: support marking a command block as random output

### DIFF
--- a/cmd/preguide/guide.go
+++ b/cmd/preguide/guide.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"text/template"
 	"text/template/parse"
 
@@ -252,16 +251,6 @@ func mustJSONMarshalIndent(i interface{}) []byte {
 	check(err, "failed to marshal prestep: %v", err)
 	return byts
 
-}
-
-func (g *guide) sanitiseVars(s string) (string, []string) {
-	var tmpls []string
-	for name, val := range g.varMap {
-		repl := g.Delims[0] + "." + name + g.Delims[1]
-		tmpls = append(tmpls, repl)
-		s = strings.ReplaceAll(s, val, repl)
-	}
-	return s, tmpls
 }
 
 var rawRegex = regexp.MustCompile(`\{%`)

--- a/cmd/preguide/step.go
+++ b/cmd/preguide/step.go
@@ -89,10 +89,12 @@ type step interface {
 
 type commandStep struct {
 	// Extract once we have a solution to cuelang.org/issue/376
-	StepType StepType
-	Name     string
-	Order    int
-	Terminal string
+	StepType      StepType
+	RandomReplace *string
+	DoNotTrim     bool
+	Name          string
+	Order         int
+	Terminal      string
 
 	Stmts []*commandStmt
 }
@@ -136,11 +138,13 @@ func (pdc *processDirContext) commandStepFromCommand(s *types.Command) (*command
 	r := strings.NewReader(s.Source)
 	f, err := syntax.NewParser().Parse(r, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse command string %q: %v", s, err)
+		return nil, fmt.Errorf("failed to parse command string %q: %v", s.Source, err)
 	}
 	res := newCommandStep(commandStep{
-		Name:     s.Name,
-		Terminal: s.Terminal,
+		Name:          s.Name,
+		RandomReplace: s.RandomReplace,
+		DoNotTrim:     s.DoNotTrim,
+		Terminal:      s.Terminal,
 	})
 	return pdc.commadStepFromSyntaxFile(res, f)
 }
@@ -159,8 +163,10 @@ func (pdc *processDirContext) commandStepFromCommandFile(s *types.CommandFile) (
 		return nil, fmt.Errorf("failed to parse commands from %v: %v", s.Path, err)
 	}
 	res := newCommandStep(commandStep{
-		Name:     s.Name,
-		Terminal: s.Terminal,
+		Name:          s.Name,
+		RandomReplace: s.RandomReplace,
+		DoNotTrim:     s.DoNotTrim,
+		Terminal:      s.Terminal,
 	})
 	return pdc.commadStepFromSyntaxFile(res, f)
 }

--- a/cmd/preguide/stmtsanitisers.go
+++ b/cmd/preguide/stmtsanitisers.go
@@ -7,7 +7,6 @@ package main
 import (
 	"github.com/play-with-go/preguide/sanitisers"
 	"github.com/play-with-go/preguide/sanitisers/cmdgo"
-	"github.com/play-with-go/preguide/sanitisers/git"
 )
 
 // stmtSanitisers is a list of stmtSanitisers for statement sanitisers. The
@@ -16,5 +15,4 @@ import (
 // question to answer in that issue is how this map comes to be populated.
 var stmtSanitisers = map[string]sanitisers.StmtSanitiser{
 	"github.com/play-with-go/preguide/cmd/preguide/sanitisers/cmdgo.CmdGoStmtSanitiser": cmdgo.CmdGoStmtSanitiser,
-	"github.com/play-with-go/preguide/cmd/preguide/sanitisers/git.GitStmtSanitiser":     git.GitStmtSanitiser,
 }

--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -144,10 +144,11 @@ Langs: {
 					CmdStr:        "echo -n \"The answer is: {{.GREETING}}!\""
 					Negated:       false
 				}]
-				Order:    0
-				Terminal: "term1"
-				StepType: 1
-				Name:     "step1"
+				Order:     0
+				DoNotTrim: false
+				Terminal:  "term1"
+				StepType:  1
+				Name:      "step1"
 			}
 		}
 	}

--- a/cmd/preguide/testdata/raw.txt
+++ b/cmd/preguide/testdata/raw.txt
@@ -89,10 +89,11 @@ Langs: {
 					CmdStr:        "echo -n \"Hello, world!\""
 					Negated:       false
 				}]
-				Order:    0
-				Terminal: "term1"
-				StepType: 1
-				Name:     "step1"
+				Order:     0
+				DoNotTrim: false
+				Terminal:  "term1"
+				StepType:  1
+				Name:      "step1"
 			}
 		}
 	}

--- a/cmd/preguide/testdata/renderer_diff.txt
+++ b/cmd/preguide/testdata/renderer_diff.txt
@@ -149,10 +149,11 @@ Langs: {
 					CmdStr:        "echo -n \"Hello\""
 					Negated:       false
 				}]
-				Order:    0
-				Terminal: "term1"
-				StepType: 1
-				Name:     "step0"
+				Order:     0
+				DoNotTrim: false
+				Terminal:  "term1"
+				StepType:  1
+				Name:      "step0"
 			}
 		}
 	}

--- a/cmd/preguide/testdata/renderers.txt
+++ b/cmd/preguide/testdata/renderers.txt
@@ -181,10 +181,11 @@ Langs: {
 					CmdStr:        "echo -n \"Hello\""
 					Negated:       false
 				}]
-				Order:    0
-				Terminal: "term1"
-				StepType: 1
-				Name:     "step0"
+				Order:     0
+				DoNotTrim: false
+				Terminal:  "term1"
+				StepType:  1
+				Name:      "step0"
 			}
 		}
 	}
@@ -238,10 +239,11 @@ Langs: {
 					CmdStr:        "echo -n \"Hello\""
 					Negated:       false
 				}]
-				Order:    0
-				Terminal: "term1"
-				StepType: 1
-				Name:     "step0"
+				Order:     0
+				DoNotTrim: false
+				Terminal:  "term1"
+				StepType:  1
+				Name:      "step0"
 			}
 		}
 	}

--- a/cmd/preguide/testdata/runargs.txt
+++ b/cmd/preguide/testdata/runargs.txt
@@ -63,10 +63,11 @@ Langs: {
 					CmdStr:        "echo -n \"The answer is: $GREETING\""
 					Negated:       false
 				}]
-				Order:    0
-				Terminal: "term1"
-				StepType: 1
-				Name:     "step1"
+				Order:     0
+				DoNotTrim: false
+				Terminal:  "term1"
+				StepType:  1
+				Name:      "step1"
 			}
 		}
 	}

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -23,6 +23,14 @@ title: A test with output that should be sanitised
 <!--step: step2 -->
 
 <!--step: step3 -->
+
+<!--step: step4 -->
+
+<!--step: step5 -->
+
+<!--step: step6 -->
+
+<!--step: step7 -->
 -- myguide/steps.cue --
 package steps
 
@@ -39,25 +47,68 @@ Terminals: term1: preguide.#Terminal & {
 
 Steps: step1: en: preguide.#Command & {
 	Source: """
-mkdir example
-cd example
-git init
-"""
+		mkdir example
+		cd example
+		git init
+		"""
 }
 
 Steps: step2: en: preguide.#Upload & {
 	Target: "/home/gopher/example/README.md"
 	Source: """
-This is a test.
-"""
+		This is a test.
+		"""
 }
 
 Steps: step3: en: preguide.#Command & {
 	Source: """
-git add -A
-git commit -am 'Initial commit'
-"""
+		git add -A
+		git commit -am 'Initial commit'
+		"""
 }
+
+Steps: step4: en: preguide.#Command & {
+	RandomReplace: "abcdefg123456789"
+	Source: """
+		git rev-parse HEAD
+		"""
+}
+
+Steps: first_random_commit: en: preguide.#Command & {
+	RandomReplace: "abcd123"
+	Source: """
+		git rev-parse --short HEAD
+		"""
+}
+
+Steps: step5: en: preguide.#Upload & {
+	Target: "/home/gopher/example/README.md"
+	Source: """
+		This is a test... again!
+		"""
+}
+
+Steps: step6: en: preguide.#Command & {
+	Source: """
+		git add -A
+		git commit -am 'Second commit'
+		"""
+}
+
+Steps: second_random_commit: en: preguide.#Command & {
+	RandomReplace: "abcd123"
+	Source: """
+		git rev-parse --short HEAD
+		"""
+}
+
+Steps: step7: en: preguide.#Command & {
+	RandomReplace: "abcdefg123456789"
+	Source: """
+		git rev-parse HEAD
+		"""
+}
+
 -- myguide/en.markdown.golden --
 ---
 guide: myguide
@@ -83,6 +134,28 @@ $ git commit -am 'Initial commit'
  create mode 100644 README.md
 ```
 {:data-command-src="Z2l0IGFkZCAtQQpnaXQgY29tbWl0IC1hbSAnSW5pdGlhbCBjb21taXQnCg=="}
+
+```.term1
+$ git rev-parse HEAD
+abcdefg123456789
+```
+{:data-command-src="Z2l0IHJldi1wYXJzZSBIRUFECg=="}
+
+<pre data-upload-path="L2hvbWUvZ29waGVyL2V4YW1wbGU=" data-upload-src="UkVBRE1FLm1k:VGhpcyBpcyBhIHRlc3QuLi4gYWdhaW4h" data-upload-term=".term1"><code class="language-md">This is a test... again!</code></pre>
+
+```.term1
+$ git add -A
+$ git commit -am 'Second commit'
+[main abcd123] Second commit
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+```
+{:data-command-src="Z2l0IGFkZCAtQQpnaXQgY29tbWl0IC1hbSAnU2Vjb25kIGNvbW1pdCcK"}
+
+```.term1
+$ git rev-parse HEAD
+abcdefg123456789
+```
+{:data-command-src="Z2l0IHJldi1wYXJzZSBIRUFECg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/en_log.txt.golden --
 Terminals: [
@@ -108,3 +181,18 @@ $ git commit -am 'Initial commit'
 [main (root-commit) abcd123] Initial commit
  1 file changed, 1 insertion(+)
  create mode 100644 README.md
+$ git rev-parse HEAD
+abcdefg123456789
+$ git rev-parse --short HEAD
+abcd123
+$ cat <<EOD > /home/gopher/example/README.md
+This is a test... again!
+EOD
+$ git add -A
+$ git commit -am 'Second commit'
+[main abcd123] Second commit
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+$ git rev-parse --short HEAD
+abcd123
+$ git rev-parse HEAD
+abcdefg123456789

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/kr/pretty v0.2.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/rogpeppe/go-internal v1.6.2
-	golang.org/x/mod v0.2.0
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -132,13 +132,29 @@ import (
 	}
 
 	// Change this to a hidden definition once cuelang.org/issue/533 is resolved
-	#stepCommon: {
+	_#stepCommon: {
 		Name:     string
 		StepType: #StepType
 		Terminal: string
 	}
 
-	#uploadCommon: {
+	_#commandCommon: {
+		_#stepCommon
+
+		// RandomReplace indicates the entire output from this command block
+		// should be used to sanitise the output from the entire script,
+		// replacing the "random" output from this command block with the
+		// value specified in RandomReplace.
+		RandomReplace?: string
+
+		// DoNotTrim indicates that when RandomReplace is set, its value
+		// should not be trimmed (the default is to trim the trailing \n
+		// from the output) prior to sanitising the output from the script
+		DoNotTrim: *false | bool
+	}
+
+	_#uploadCommon: {
+		_#stepCommon
 		Target: string
 
 		// The language of the content being uploaded, e.g. go
@@ -153,27 +169,25 @@ import (
 	}
 
 	#Command: {
-		#stepCommon
+		_#commandCommon
 		StepType: #StepTypeCommand
 		Source:   string
 	}
 
 	#CommandFile: {
-		#stepCommon
+		_#commandCommon
 		StepType: #StepTypeCommandFile
 		Path:     string
 	}
 
 	#Upload: {
-		#stepCommon
-		#uploadCommon
+		_#uploadCommon
 		StepType: #StepTypeUpload
 		Source:   string
 	}
 
 	#UploadFile: {
-		#stepCommon
-		#uploadCommon
+		_#uploadCommon
 		StepType: #StepTypeUploadFile
 		Path:     string
 	}
@@ -328,7 +342,7 @@ _#rendererCommon: {
 // reference to https://gist.github.com/myitcv/399ed50f792b49ae7224ee5cb3e504fa#file-304b02e-cue
 //
 // 1. Move to the use of #TerminalName (probably hidden) as a type for a terminal's
-// name in #stepCommon
+// name in _#stepCommon
 // 2. Try and move to the advanced definition of Steps: [string]: [lang] to be the
 // disjunction of #Step or [scenario]: #Step
 // 3. Ensure that a step's name can be defaulted for this advanced definition (i.e.

--- a/internal/types/guide.go
+++ b/internal/types/guide.go
@@ -122,10 +122,12 @@ type Step interface {
 }
 
 type Command struct {
-	StepTypeVal StepType `json:"StepType"`
-	Terminal    string
-	Name        string
-	Source      string
+	StepTypeVal   StepType `json:"StepType"`
+	Terminal      string
+	Name          string
+	RandomReplace *string
+	DoNotTrim     bool
+	Source        string
 }
 
 var _ Step = (*Command)(nil)
@@ -135,10 +137,12 @@ func (c *Command) StepType() StepType {
 }
 
 type CommandFile struct {
-	StepTypeVal StepType `json:"StepType"`
-	Terminal    string
-	Name        string
-	Path        string
+	StepTypeVal   StepType `json:"StepType"`
+	Terminal      string
+	Name          string
+	RandomReplace *string
+	DoNotTrim     bool
+	Path          string
 }
 
 var _ Step = (*CommandFile)(nil)

--- a/preguide.cue
+++ b/preguide.cue
@@ -23,13 +23,29 @@ import (
 	}
 
 	// Change this to a hidden definition once cuelang.org/issue/533 is resolved
-	#stepCommon: {
+	_#stepCommon: {
 		Name:     string
 		StepType: #StepType
 		Terminal: string
 	}
 
-	#uploadCommon: {
+	_#commandCommon: {
+		_#stepCommon
+
+		// RandomReplace indicates the entire output from this command block
+		// should be used to sanitise the output from the entire script,
+		// replacing the "random" output from this command block with the
+		// value specified in RandomReplace.
+		RandomReplace?: string
+
+		// DoNotTrim indicates that when RandomReplace is set, its value
+		// should not be trimmed (the default is to trim the trailing \n
+		// from the output) prior to sanitising the output from the script
+		DoNotTrim: *false | bool
+	}
+
+	_#uploadCommon: {
+		_#stepCommon
 		Target: string
 
 		// The language of the content being uploaded, e.g. go
@@ -44,27 +60,25 @@ import (
 	}
 
 	#Command: {
-		#stepCommon
+		_#commandCommon
 		StepType: #StepTypeCommand
 		Source:   string
 	}
 
 	#CommandFile: {
-		#stepCommon
+		_#commandCommon
 		StepType: #StepTypeCommandFile
 		Path:     string
 	}
 
 	#Upload: {
-		#stepCommon
-		#uploadCommon
+		_#uploadCommon
 		StepType: #StepTypeUpload
 		Source:   string
 	}
 
 	#UploadFile: {
-		#stepCommon
-		#uploadCommon
+		_#uploadCommon
 		StepType: #StepTypeUploadFile
 		Path:     string
 	}
@@ -219,7 +233,7 @@ _#rendererCommon: {
 // reference to https://gist.github.com/myitcv/399ed50f792b49ae7224ee5cb3e504fa#file-304b02e-cue
 //
 // 1. Move to the use of #TerminalName (probably hidden) as a type for a terminal's
-// name in #stepCommon
+// name in _#stepCommon
 // 2. Try and move to the advanced definition of Steps: [string]: [lang] to be the
 // disjunction of #Step or [scenario]: #Step
 // 3. Ensure that a step's name can be defaulted for this advanced definition (i.e.

--- a/sanitisers/cmdgo/go.go
+++ b/sanitisers/cmdgo/go.go
@@ -21,22 +21,11 @@ const (
 var (
 	goTestPassRunHeading = regexp.MustCompile(`^( *--- (PASS|FAIL): .+\()` + goTestTestTime + `\)$`)
 	goTestFailSummary    = regexp.MustCompile(`^((FAIL|ok  )\t.+\t)` + goTestTestTime + `$`)
-
-	pseudoVersion *regexp.Regexp
 )
-
-func init() {
-	// pseudoVersion is based on the definition in internal/modfetch
-	pseudoVersion = regexp.MustCompile(`(v[0-9]+\.(?:0\.0-|\d+\.\d+-(?:[^+]*\.)?0\.))\d{14}-[A-Za-z0-9]+(\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?`)
-	pseudoVersion.Longest()
-}
 
 func CmdGoStmtSanitiser(s *sanitisers.S, stmt *syntax.Stmt) sanitisers.Sanitiser {
 	if s.StmtHasCallExprPrefix(stmt, "go", "test") {
 		return sanitiseGoTest
-	}
-	if s.StmtHasCallExprPrefix(stmt, "go", "get") {
-		return sanitiseGoGet
 	}
 	return nil
 }
@@ -46,23 +35,6 @@ func sanitiseGoTest(varNames []string, s string) string {
 	for i := range lines {
 		lines[i] = goTestPassRunHeading.ReplaceAllString(lines[i], fmt.Sprintf("${1}%v)", goTestMagicTime))
 		lines[i] = goTestFailSummary.ReplaceAllString(lines[i], "${1}"+goTestMagicTime)
-	}
-	return strings.Join(lines, "\n")
-}
-
-// sanitiseGoGet finds lines that include {{.ENV}} patterns, and then replaces
-// all psuedoversions on that line. If this logic needs to be refined for more
-// precise replacing of pseudo versions, so be it: add the complexity below
-func sanitiseGoGet(varNames []string, s string) string {
-	lines := strings.Split(s, "\n")
-	for _, v := range varNames {
-		for i := range lines {
-			vRegexp := regexp.MustCompile(regexp.QuoteMeta(v))
-			if !vRegexp.MatchString(lines[i]) {
-				continue
-			}
-			lines[i] = pseudoVersion.ReplaceAllString(lines[i], "${1}20060102150405-abcde12345${2}")
-		}
 	}
 	return strings.Join(lines, "\n")
 }

--- a/sanitisers/cmdgo/go_test.go
+++ b/sanitisers/cmdgo/go_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"golang.org/x/mod/semver"
 )
 
 func TestSanitiseGoTest(t *testing.T) {
@@ -64,56 +63,4 @@ FAIL
 			}
 		})
 	}
-}
-
-func TestPseudoVersion(t *testing.T) {
-	testCases := []struct {
-		in   string
-		want bool
-	}{
-		{"v0.0.0-20200901194510-cc2d21bd1e55", true},
-		{"v2.3.0-pre.0.20060102150405-hash+incompatible", true},
-		{"v1.0.1-0.20060102150405-hash+metadata", true},
-		{"v1.4.3", false},
-		{"v1.4.3-other", false},
-		{"v1.4.3+something", false},
-	}
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("TestPseudoVersion_%v", i), func(t *testing.T) {
-			got := pseudoVersion.MatchString(tc.in)
-			if !semver.IsValid(tc.in) {
-				t.Errorf("semver.IsValid(%q) == false, want true", tc.in)
-			}
-			if got && !tc.want {
-				t.Errorf("got a match where we did not expect one")
-			} else if !got && tc.want {
-				t.Errorf("failed to find a match where we expected one ")
-			}
-		})
-	}
-}
-
-func TestSanitiseGoGet(t *testing.T) {
-	testCases := []struct {
-		vars []string
-		in   string
-		want string
-	}{{
-		vars: []string{"{{.REPO1}}"},
-		in: `go: downloading gopher.live/x/{{.REPO1}} v2.0.0-20200901194510-cc2d21bd1e55+something
-go: gopher.live/x/{{.REPO1}} upgrade => v0.0.0-20200901194510-cc2d21bd1e55
-`,
-		want: `go: downloading gopher.live/x/{{.REPO1}} v2.0.0-20060102150405-abcde12345+something
-go: gopher.live/x/{{.REPO1}} upgrade => v0.0.0-20060102150405-abcde12345
-`,
-	}}
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("TestSanitiseGoGet_%v", i), func(t *testing.T) {
-			got := sanitiseGoGet(tc.vars, tc.in)
-			if got != tc.want {
-				t.Fatalf("failed to get sanitised output: %v", cmp.Diff(got, tc.want))
-			}
-		})
-	}
-
 }


### PR DESCRIPTION
Command blocks that are marked in this way have their output included
along with the result of prestep variables in the first step of
sanitisation of output. Then the existing command sanitisers run.

As part of this change we delete the git sanitiser, because that output
can more easily be handled by using the command block sanitisation.