### PR TITLE
cmd/preguide: remove concept of trimmed output from out package

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -1128,7 +1128,6 @@ func (pdc *processDirContext) runBashFile(g *guide, ls *langSteps) {
 				if doRandomReplace {
 					stepOutput.WriteString(stmt.Output)
 				}
-				stmt.TrimmedOutput = trimTrailingNewline(stmt.Output)
 				exitCodeStr := slurp([]byte("\n"))
 				stmt.ExitCode, err = strconv.Atoi(exitCodeStr)
 				check(err, "failed to parse exit code from %q at position %v in output: %v\n%s", exitCodeStr, len(out)-len(walk)-len(exitCodeStr)-1, err, out)

--- a/cmd/preguide/step.go
+++ b/cmd/preguide/step.go
@@ -121,12 +121,11 @@ func (c *commandStep) setorder(i int) {
 }
 
 type commandStmt struct {
-	Negated       bool
-	CmdStr        string
-	ExitCode      int
-	Output        string
-	TrimmedOutput string
-	outputFence   string
+	Negated     bool
+	CmdStr      string
+	ExitCode    int
+	Output      string
+	outputFence string
 
 	sanitisers []sanitisers.Sanitiser
 }
@@ -255,7 +254,6 @@ func (c *commandStep) setOutputFrom(s step) {
 	for i, s := range oc.Stmts {
 		c.Stmts[i].ExitCode = s.ExitCode
 		c.Stmts[i].Output = s.Output
-		c.Stmts[i].TrimmedOutput = s.TrimmedOutput
 	}
 }
 

--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -138,11 +138,10 @@ Langs: {
 		Steps: {
 			step1: {
 				Stmts: [{
-					TrimmedOutput: "The answer is: Hello, world!!"
-					Output:        "The answer is: Hello, world!!"
-					ExitCode:      0
-					CmdStr:        "echo -n \"The answer is: {{.GREETING}}!\""
-					Negated:       false
+					Output:   "The answer is: Hello, world!!"
+					ExitCode: 0
+					CmdStr:   "echo -n \"The answer is: {{.GREETING}}!\""
+					Negated:  false
 				}]
 				Order:     0
 				DoNotTrim: false

--- a/cmd/preguide/testdata/out_refs.txt
+++ b/cmd/preguide/testdata/out_refs.txt
@@ -27,8 +27,6 @@ Here we talk about the second of those commands, `<!--outref: cmd_false -->`.
 
 We also present the output of `<!--outref: echo_out-->`.
 
-We also present the trimmed output of `<!--outref: trimmed_echo_out-->`.
-
 -- myguide/guide.cue --
 package guide
 
@@ -56,7 +54,6 @@ package out
 
 Defs: {
 	echo_out:         Langs.en.Steps.step1.Stmts[0].Output
-	trimmed_echo_out: Langs.en.Steps.step1.Stmts[0].TrimmedOutput
 	cmd_false:        Langs.en.Steps.step1.Stmts[2].CmdStr
 }
 -- myguide/en.md.golden --
@@ -91,7 +88,5 @@ Here we talk about the second of those commands, `false`.
 
 We also present the output of `Hello, world!
 `.
-
-We also present the trimmed output of `Hello, world!`.
 
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>

--- a/cmd/preguide/testdata/raw.txt
+++ b/cmd/preguide/testdata/raw.txt
@@ -83,11 +83,10 @@ Langs: {
 			}
 			step1: {
 				Stmts: [{
-					TrimmedOutput: "Hello, world!"
-					Output:        "Hello, world!"
-					ExitCode:      0
-					CmdStr:        "echo -n \"Hello, world!\""
-					Negated:       false
+					Output:   "Hello, world!"
+					ExitCode: 0
+					CmdStr:   "echo -n \"Hello, world!\""
+					Negated:  false
 				}]
 				Order:     0
 				DoNotTrim: false

--- a/cmd/preguide/testdata/renderer_diff.txt
+++ b/cmd/preguide/testdata/renderer_diff.txt
@@ -143,11 +143,10 @@ Langs: {
 			}
 			step0: {
 				Stmts: [{
-					TrimmedOutput: "Hello"
-					Output:        "Hello"
-					ExitCode:      0
-					CmdStr:        "echo -n \"Hello\""
-					Negated:       false
+					Output:   "Hello"
+					ExitCode: 0
+					CmdStr:   "echo -n \"Hello\""
+					Negated:  false
 				}]
 				Order:     0
 				DoNotTrim: false

--- a/cmd/preguide/testdata/renderers.txt
+++ b/cmd/preguide/testdata/renderers.txt
@@ -175,11 +175,10 @@ Langs: {
 			}
 			step0: {
 				Stmts: [{
-					TrimmedOutput: "Hello"
-					Output:        "Hello"
-					ExitCode:      0
-					CmdStr:        "echo -n \"Hello\""
-					Negated:       false
+					Output:   "Hello"
+					ExitCode: 0
+					CmdStr:   "echo -n \"Hello\""
+					Negated:  false
 				}]
 				Order:     0
 				DoNotTrim: false
@@ -233,11 +232,10 @@ Langs: {
 			}
 			step0: {
 				Stmts: [{
-					TrimmedOutput: "Hello"
-					Output:        "Hello"
-					ExitCode:      0
-					CmdStr:        "echo -n \"Hello\""
-					Negated:       false
+					Output:   "Hello"
+					ExitCode: 0
+					CmdStr:   "echo -n \"Hello\""
+					Negated:  false
 				}]
 				Order:     0
 				DoNotTrim: false

--- a/cmd/preguide/testdata/runargs.txt
+++ b/cmd/preguide/testdata/runargs.txt
@@ -57,11 +57,10 @@ Langs: {
 		Steps: {
 			step1: {
 				Stmts: [{
-					TrimmedOutput: "The answer is: hello"
-					Output:        "The answer is: hello"
-					ExitCode:      0
-					CmdStr:        "echo -n \"The answer is: $GREETING\""
-					Negated:       false
+					Output:   "The answer is: hello"
+					ExitCode: 0
+					CmdStr:   "echo -n \"The answer is: $GREETING\""
+					Negated:  false
 				}]
 				Order:     0
 				DoNotTrim: false

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -71,10 +71,6 @@ _#stepCommon: {
 	CmdStr:   string
 	ExitCode: int
 	Output:   string
-
-	// TrimmedOutput is the Output from the statement
-	// with the trailing \n removed
-	TrimmedOutput: string
 }
 
 #UploadStep: {

--- a/out/out.cue
+++ b/out/out.cue
@@ -55,10 +55,6 @@ _#stepCommon: {
 	CmdStr:   string
 	ExitCode: int
 	Output:   string
-
-	// TrimmedOutput is the Output from the statement
-	// with the trailing \n removed
-	TrimmedOutput: string
 }
 
 #UploadStep: {


### PR DESCRIPTION
The use/need for defining definitions within the out package remains to
be really proven.

Stable output like go version can simply be shown as a command block,
indeed that's more useful to the user

Unstable output cannot be included in prose in any case because it would
only be the sanitised output, not the actual output.

Rather than totally removing this concept, we instead remove the
TrimmedOutput field to simplify it.