### PR TITLE
cmd/preguide: print full CUE errors

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -589,7 +589,11 @@ func (pdc *processDirContext) loadAndValidateSteps(g *guide) (hasStepsToRun bool
 	// below)
 	gv = gv.Unify(pdc.schemas.Guide)
 	err = gv.Validate()
-	check(err, "%v does not satisfy github.com/play-with-go/preguide.#Guide: %v", gp.ImportPath, err)
+	if err != nil {
+		var errstr strings.Builder
+		errors.Print(&errstr, err, nil)
+		raise("%v does not satisfy github.com/play-with-go/preguide.#Guide: %v", gp.ImportPath, errstr.String())
+	}
 
 	var intGuide types.Guide
 	err = gv.Decode(&intGuide)


### PR DESCRIPTION
We can trim this back later, but for now at least it should provide much
more relevant context than the short version does.