### PR TITLE
cmd/preguide: log the bash script that ran on output parse error

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -1126,7 +1126,9 @@ func (pdc *processDirContext) runBashFile(g *guide, ls *langSteps) {
 				// TODO: tidy this up
 				fence := []byte(stmt.outputFence + "\n")
 				if !bytes.HasPrefix(walk, fence) {
-					raise("failed to find %q at position %v in output:\n%s", stmt.outputFence, len(out)-len(walk), out)
+					// Also log the bash script in this error case to try and track down
+					// the random failures we have been seeing
+					raise("failed to find %q at position %v in output:\n%s\nBash script was: %v\n", stmt.outputFence, len(out)-len(walk), out, toWrite)
 				}
 				walk = walk[len(fence):]
 				stmt.Output = slurp(fence)


### PR DESCRIPTION
We have seen one or two random failures where the output of the bash
script could not be parsed because some random output appears after an
exit code but before the next output fence.

Output the bash script that ran in that case to try and understand what
is going on.