### PR TITLE
cmd/preguide: add directive position information

### DIFF
--- a/cmd/preguide/guide.go
+++ b/cmd/preguide/guide.go
@@ -138,7 +138,7 @@ func (pdc *processDirContext) writeGuideOutput() {
 			// TODO: implement fallback to en for directives
 			pos := 0
 			for _, d := range md.directives {
-				buf.Write(md.content[pos:d.Pos()])
+				buf.Write(md.content[pos:d.Pos().offset])
 				switch d := d.(type) {
 				case *stepDirective:
 					g.Steps[d.Key()].render(pdc.fMode, &buf)
@@ -157,7 +157,7 @@ func (pdc *processDirContext) writeGuideOutput() {
 				default:
 					panic(fmt.Errorf("don't yet know how to handle %T directives", d))
 				}
-				pos = d.End()
+				pos = d.End().offset
 			}
 			buf.Write(md.content[pos:])
 		} else {

--- a/cmd/preguide/testdata/missing_step.txt
+++ b/cmd/preguide/testdata/missing_step.txt
@@ -2,7 +2,7 @@
 
 ! preguide gen -out _output
 ! stdout .+
-stderr 'unknown step "step1" referened in file '$WORK'[/\\]myguide[/\\]en\.md'
+stderr 'myguide/en.md:3:1: unknown step "step1" referened'
 
 -- myguide/en.md --
 # Step 1

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -126,7 +126,6 @@ import (
 		Terminal: string
 	}
 
-	// Change this to a hidden definition once cuelang.org/issue/533 is resolved
 	_#stepCommon: {
 		Name:     string
 		StepType: #StepType
@@ -150,6 +149,7 @@ import (
 
 	_#uploadCommon: {
 		_#stepCommon
+
 		Target: string
 
 		// The language of the content being uploaded, e.g. go
@@ -216,8 +216,6 @@ import (
 	Scenarios: [name=string]: {
 		Name: name
 	}
-
-	_#ScenarioName: or([ for name, _ in Scenarios {name}])
 
 	for scenario, _ in Scenarios for terminal, _ in Terminals {
 		Terminals: "\(terminal)": Scenarios: "\(scenario)": #TerminalScenario

--- a/preguide.cue
+++ b/preguide.cue
@@ -25,7 +25,6 @@ import (
 		Terminal: string
 	}
 
-	// Change this to a hidden definition once cuelang.org/issue/533 is resolved
 	_#stepCommon: {
 		Name:     string
 		StepType: #StepType
@@ -49,6 +48,7 @@ import (
 
 	_#uploadCommon: {
 		_#stepCommon
+
 		Target: string
 
 		// The language of the content being uploaded, e.g. go
@@ -115,8 +115,6 @@ import (
 	Scenarios: [name=string]: {
 		Name: name
 	}
-
-	_#ScenarioName: or([ for name, _ in Scenarios {name}])
 
 	for scenario, _ in Scenarios for terminal, _ in Terminals {
 		Terminals: "\(terminal)": Scenarios: "\(scenario)": #TerminalScenario


### PR DESCRIPTION
So that we can provide human-readable error information for directives
in markdown files