### PR TITLE
cmd/preguide: tighter checks on step directives

### DIFF
--- a/cmd/preguide/step.go
+++ b/cmd/preguide/step.go
@@ -69,6 +69,7 @@ type step interface {
 	render(types.Mode, io.Writer)
 	renderLog(types.Mode, io.Writer)
 	setOutputFrom(step)
+	mustBeReferenced() bool
 }
 
 type commandStep struct {
@@ -241,6 +242,10 @@ func (c *commandStep) setOutputFrom(s step) {
 	}
 }
 
+func (c *commandStep) mustBeReferenced() bool {
+	return c.RandomReplace == nil
+}
+
 func trimTrailingNewline(s string) string {
 	trimmed := s
 	if len(trimmed) > 0 && trimmed[len(trimmed)-1] == '\n' {
@@ -349,6 +354,10 @@ func (u *uploadStep) render(mode types.Mode, w io.Writer) {
 		fmt.Fprintf(w, "%s", renderedSource)
 		fmt.Fprintf(w, "```n")
 	}
+}
+
+func (u *uploadStep) mustBeReferenced() bool {
+	return true
 }
 
 func base64Encode(s string) string {

--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -25,6 +25,11 @@ cmp myguide/en_log.txt myguide/en_log.txt.golden
 ---
 title: A test with all directives
 ---
+
+# Step 0
+
+<!--step: step0 -->
+
 # Step 1
 
 <!--step: step1 -->
@@ -97,6 +102,14 @@ guide: myguide
 lang: en
 title: A test with all directives
 ---
+
+# Step 0
+
+```.term1
+$ mkdir nooutput
+```
+{:data-command-src="bWtkaXIgbm9vdXRwdXQK"}
+
 # Step 1
 
 ```.term1

--- a/cmd/preguide/testdata/bad_guide.txt
+++ b/cmd/preguide/testdata/bad_guide.txt
@@ -4,7 +4,7 @@
 # Intial run
 ! preguide gen -out _output
 ! stdout .+
-stderr 'error processing '$WORK'/myguide: failed to validate CUE package: field `Banana` not allowed'
+stderr 'myguide: failed to validate CUE package: field `Banana` not allowed'
 
 -- myguide/en.markdown --
 ---

--- a/cmd/preguide/testdata/github.txt
+++ b/cmd/preguide/testdata/github.txt
@@ -31,12 +31,6 @@ Terminals: term1: preguide.#Terminal & {
 	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
-Steps: step0: preguide.#Command & {
-	Source: """
-mkdir nooutput
-"""
-}
-
 Steps: step1: preguide.#Command & {
 	Source: """
 echo "Hello, world! I am a #Command"
@@ -66,7 +60,6 @@ $ touch blah
 $ false
 $ ls
 blah
-nooutput
 ```
 
 # Step 2

--- a/cmd/preguide/testdata/limitations.txt
+++ b/cmd/preguide/testdata/limitations.txt
@@ -5,13 +5,13 @@
 # hence non-English langage guide should fail
 ! preguide gen -out demarkdown/_output -dir demarkdown
 ! stdout .+
-stderr 'error processing '$WORK'/demarkdown/guide: we only support English language guides for now'
+stderr 'demarkdown/guide: we only support English language guides for now'
 
 # Only support English language guides for now (hence a single language)
 # hence non-English steps should fail
 ! preguide gen -out desteps/_output -dir desteps
 ! stdout .+
-stderr 'error processing '$WORK'/desteps/guide: failed to validate CUE package: Steps.step1: field `de` not allowed:'
+stderr 'desteps/guide: failed to validate CUE package: Steps.step1: field `de` not allowed:'
 
 # Only support a single terminal
 ! preguide gen -out multipleterminals/_output -dir multipleterminals

--- a/cmd/preguide/testdata/missing_step.txt
+++ b/cmd/preguide/testdata/missing_step.txt
@@ -2,9 +2,15 @@
 
 ! preguide gen -out _output
 ! stdout .+
-stderr 'myguide/en.md:3:1: unknown step "step1" referened'
+stderr '^myguide/en.md:9:1: unknown step "step1" referened$'
 
 -- myguide/en.md --
+---
+layout: rubbish
+title:  "A bad title"
+categories: beginner
+---
+
 # Step 1
 
 <!--step: step1 -->

--- a/cmd/preguide/testdata/parallel.txt
+++ b/cmd/preguide/testdata/parallel.txt
@@ -34,12 +34,6 @@ Terminals: term1: preguide.#Terminal & {
 	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
-Steps: step0: preguide.#Command & {
-	Source: """
-mkdir nooutput
-"""
-}
-
 Steps: step1: preguide.#Command & {
 	Source: """
 echo "Hello, world! I am a #Command"
@@ -83,12 +77,6 @@ Terminals: term1: preguide.#Terminal & {
 	Scenarios: go115: Image: "this_will_never_be_used"
 }
 
-Steps: step0: preguide.#Command & {
-	Source: """
-mkdir nooutput
-"""
-}
-
 Steps: step1: preguide.#Command & {
 	Source: """
 echo "Hello, world! I am a #Command"
@@ -122,7 +110,6 @@ $ touch blah
 $ false
 $ ls
 blah
-nooutput
 ```
 {:data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"}
 
@@ -144,14 +131,12 @@ Terminals: [
     }
   }
 ]
-$ mkdir nooutput
 $ echo "Hello, world! I am a #Command"
 Hello, world! I am a #Command
 $ touch blah
 $ false
 $ ls
 blah
-nooutput
 $ cat <<EOD > /scripts/somewhere.sh
 #!/usr/bin/env bash
 
@@ -172,7 +157,6 @@ $ touch blah
 $ false
 $ ls
 blah
-nooutput
 ```
 {:data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"}
 
@@ -194,14 +178,12 @@ Terminals: [
     }
   }
 ]
-$ mkdir nooutput
 $ echo "Hello, world! I am a #Command"
 Hello, world! I am a #Command
 $ touch blah
 $ false
 $ ls
 blah
-nooutput
 $ cat <<EOD > /scripts/somewhere.sh
 #!/usr/bin/env bash
 

--- a/cmd/preguide/testdata/raw.txt
+++ b/cmd/preguide/testdata/raw.txt
@@ -12,6 +12,8 @@ title: myguide
 ---
 
 <!--step: step1 -->
+
+<!--step: step2 -->
 -- myguide/steps.cue --
 package steps
 

--- a/cmd/preguide/testdata/step_not_referenced.txt
+++ b/cmd/preguide/testdata/step_not_referenced.txt
@@ -1,0 +1,73 @@
+# Test that we get the expected error message when we fail to
+# reference a step
+
+! preguide gen -out _output
+! stdout .+
+cmp stderr myguide/stderr.txt
+
+-- myguide/en.markdown --
+---
+title: A test with all directives
+---
+
+# Step 0
+
+<!--step: step0 -->
+
+-- myguide/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Steps: step0: preguide.#Command & {
+	Source: """
+mkdir nooutput
+"""
+}
+
+Steps: step1: preguide.#Command & {
+	Source: """
+echo "Hello, world! I am a #Command"
+touch blah
+! false
+ls
+"""
+}
+
+Steps: step2: preguide.#CommandFile & {
+	Path: "step2_commandFile.sh"
+}
+
+Steps: step3: preguide.#Upload & {
+	Target:   "/scripts/somewhere.sh"
+	Source: """
+#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"
+"""
+}
+
+Steps: step4: preguide.#UploadFile & {
+	Language: "bash" // Vary the language for fun
+	Target:   "/scripts/step2.sh"
+	Path:     "step2_uploadFile.sh"
+}
+-- myguide/step2_commandFile.sh --
+echo "Hello, world! I am a #CommandFile"
+-- myguide/step2_uploadFile.sh --
+echo "Hello, world! I am an #UploadFile"
+-- myguide/stderr.txt --
+myguide/en.markdown:9: step "step1" was not referenced
+	myguide/en.markdown:9: step "step2" was not referenced
+	myguide/en.markdown:9: step "step3" was not referenced
+	myguide/en.markdown:9: step "step4" was not referenced
+

--- a/cmd/preguide/testdata/steps_referenced_out_of_order.txt
+++ b/cmd/preguide/testdata/steps_referenced_out_of_order.txt
@@ -1,0 +1,66 @@
+# Test that we get the expected error message when we reference
+# steps in the wrong order
+
+! preguide gen -out _output
+! stdout .+
+cmpenv stderr myguide/stderr.txt
+
+-- myguide/en.markdown --
+---
+title: A test with all directives
+---
+
+<!--step: step0 -->
+<!--step: step2 -->
+<!--step: step1 -->
+<!--step: step3 -->
+
+-- myguide/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Steps: step0: preguide.#Command & {
+	Source: """
+mkdir nooutput
+"""
+}
+
+Steps: step1: preguide.#Command & {
+	Source: """
+echo "Hello, world! I am a #Command"
+touch blah
+! false
+ls
+"""
+}
+
+Steps: step2: preguide.#CommandFile & {
+	Path: "step2_commandFile.sh"
+}
+
+Steps: step3: preguide.#Upload & {
+	Target:   "/scripts/somewhere.sh"
+	Source: """
+#!/usr/bin/env bash
+
+echo "Hello, world! I am an #Upload"
+"""
+}
+
+-- myguide/step2_commandFile.sh --
+echo "Hello, world! I am a #CommandFile"
+-- myguide/step2_uploadFile.sh --
+echo "Hello, world! I am an #UploadFile"
+-- myguide/stderr.txt --
+myguide/en.markdown:6:1: saw step directive step2; expected to see step1
+

--- a/cmd/preguide/util.go
+++ b/cmd/preguide/util.go
@@ -93,7 +93,7 @@ type chunker struct {
 	prevSeqStart position
 }
 
-func newChunker(b []byte, beg, end string) *chunker {
+func newChunker(b []byte, beg, end string, startLine int) *chunker {
 	if strings.Contains(beg, "\n") || strings.Contains(end, "\n") {
 		panic(fmt.Errorf("cannot have a begin or end sequence that contains newline"))
 	}
@@ -103,9 +103,9 @@ func newChunker(b []byte, beg, end string) *chunker {
 		endSeq:   []byte(end),
 	}
 	// 1-initialise line values
-	res.currPoint.line = 1
-	res.endPoint.line = 1
-	res.prevSeqStart.line = 1
+	res.currPoint.line = startLine
+	res.endPoint.line = startLine
+	res.prevSeqStart.line = startLine
 	return res
 }
 


### PR DESCRIPTION
Ensure that:

* we only reference steps that exist
* that we reference them in the correct order
* that we reference all steps that need to be referenced