### PR TITLE
cmd/preguide: add further debug log output

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -1478,6 +1478,7 @@ func (pdc *processDirContext) buildBashFile(g *guide) {
 			panic(fmt.Errorf("can't yet handle steps of type %T", step))
 		}
 	}
+	pdc.debugf("bash script:\n%v", sb.String())
 	g.bashScript = sb.String()
 	g.Hash = fmt.Sprintf("%x", h.Sum(nil))
 }


### PR DESCRIPTION
We are still getting out-of-order output on PWG; this will help pin
things down further.