### PR TITLE
cmd/preguide: allocate a tty when running a script

### DIFF
--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -118,8 +118,7 @@ Hello, world! I am a #Command
 $ touch blah
 $ false
 $ ls
-blah
-nooutput
+blah  nooutput
 ```
 {:data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"}
 
@@ -160,8 +159,7 @@ Hello, world! I am a #Command
 $ touch blah
 $ false
 $ ls
-blah
-nooutput
+blah  nooutput
 $ echo "Hello, world! I am a #CommandFile"
 Hello, world! I am a #CommandFile
 $ cat <<EOD > /scripts/somewhere.sh


### PR DESCRIPTION
This ensures that the output from the script is flushed on every
newline, regardless of whether it is stdout or stderr