### PR TITLE
cmd/preguide: set TERM=dumb and NO_COLOR=true

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -1435,6 +1435,8 @@ func (pdc *processDirContext) buildBashFile(g *guide) {
 	// reproducibility they should specify the full digest.
 	hf("image: %v\n", g.Image())
 	pf("#!/usr/bin/env bash\n")
+	pf("export TERM=dumb\n")
+	pf("export NO_COLOR=true\n")
 	for _, step := range g.steps {
 		switch step := step.(type) {
 		case *commandStep:


### PR DESCRIPTION
Because our "terminal" (the buffer that receives the output of the
script run within Docker) is simply not capable of anything. So any
escape sequences will simply look wrong in the prose part of the guide.