### PR TITLE
cmd/preguide: define InformationOnly on command step

### DIFF
--- a/cmd/preguide/step.go
+++ b/cmd/preguide/step.go
@@ -74,12 +74,13 @@ type step interface {
 
 type commandStep struct {
 	// Extract once we have a solution to cuelang.org/issue/376
-	StepType      StepType
-	RandomReplace *string
-	DoNotTrim     bool
-	Name          string
-	Order         int
-	Terminal      string
+	StepType        StepType
+	RandomReplace   *string
+	DoNotTrim       bool
+	InformationOnly bool
+	Name            string
+	Order           int
+	Terminal        string
 
 	Stmts []*commandStmt
 }
@@ -125,10 +126,11 @@ func (pdc *processDirContext) commandStepFromCommand(s *types.Command) (*command
 		return nil, fmt.Errorf("failed to parse command string %q: %v", s.Source, err)
 	}
 	res := newCommandStep(commandStep{
-		Name:          s.Name,
-		RandomReplace: s.RandomReplace,
-		DoNotTrim:     s.DoNotTrim,
-		Terminal:      s.Terminal,
+		Name:            s.Name,
+		RandomReplace:   s.RandomReplace,
+		InformationOnly: s.InformationOnly,
+		DoNotTrim:       s.DoNotTrim,
+		Terminal:        s.Terminal,
 	})
 	return pdc.commadStepFromSyntaxFile(res, f)
 }
@@ -147,10 +149,11 @@ func (pdc *processDirContext) commandStepFromCommandFile(s *types.CommandFile) (
 		return nil, fmt.Errorf("failed to parse commands from %v: %v", s.Path, err)
 	}
 	res := newCommandStep(commandStep{
-		Name:          s.Name,
-		RandomReplace: s.RandomReplace,
-		DoNotTrim:     s.DoNotTrim,
-		Terminal:      s.Terminal,
+		Name:            s.Name,
+		RandomReplace:   s.RandomReplace,
+		InformationOnly: s.InformationOnly,
+		DoNotTrim:       s.DoNotTrim,
+		Terminal:        s.Terminal,
 	})
 	return pdc.commadStepFromSyntaxFile(res, f)
 }
@@ -243,7 +246,7 @@ func (c *commandStep) setOutputFrom(s step) {
 }
 
 func (c *commandStep) mustBeReferenced() bool {
-	return c.RandomReplace == nil
+	return !c.InformationOnly
 }
 
 func trimTrailingNewline(s string) string {

--- a/cmd/preguide/testdata/bad_guide.txt
+++ b/cmd/preguide/testdata/bad_guide.txt
@@ -4,7 +4,7 @@
 # Intial run
 ! preguide gen -out _output
 ! stdout .+
-stderr 'myguide: failed to validate CUE package: field `Banana` not allowed'
+stderr 'myguide: sanity check failed: failed to validate CUE package: field `Banana` not allowed'
 
 -- myguide/en.markdown --
 ---

--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -140,11 +140,12 @@ Steps: {
 			CmdStr:   "echo -n \"The answer is: {{.GREETING}}!\""
 			Negated:  false
 		}]
-		Order:     0
-		DoNotTrim: false
-		Terminal:  "term1"
-		StepType:  1
-		Name:      "step1"
+		Order:           0
+		InformationOnly: false
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "step1"
 	}
 }
 Hash: "e419ad5f6c5f02aa9c78658abb5b4ef480ebc0783a23072224c9c38d8c4ff830"

--- a/cmd/preguide/testdata/limitations.txt
+++ b/cmd/preguide/testdata/limitations.txt
@@ -11,7 +11,7 @@ stderr 'demarkdown/guide: we only support English language guides for now'
 # hence non-English steps should fail
 ! preguide gen -out desteps/_output -dir desteps
 ! stdout .+
-stderr 'desteps/guide: failed to validate CUE package: Steps.step1: field `de` not allowed:'
+stderr 'desteps/guide: sanity check failed: failed to validate CUE package: Steps.step1: field `de` not allowed:'
 
 # Only support a single terminal
 ! preguide gen -out multipleterminals/_output -dir multipleterminals

--- a/cmd/preguide/testdata/raw.txt
+++ b/cmd/preguide/testdata/raw.txt
@@ -87,11 +87,12 @@ Steps: {
 			CmdStr:   "echo -n \"Hello, world!\""
 			Negated:  false
 		}]
-		Order:     0
-		DoNotTrim: false
-		Terminal:  "term1"
-		StepType:  1
-		Name:      "step1"
+		Order:           0
+		InformationOnly: false
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "step1"
 	}
 }
 Hash: "c3ff9c8755cc05011560b487162a59cc316da54934b4dd0ac5796bdebd64c0b5"

--- a/cmd/preguide/testdata/renderer_diff.txt
+++ b/cmd/preguide/testdata/renderer_diff.txt
@@ -145,11 +145,12 @@ Steps: {
 			CmdStr:   "echo -n \"Hello\""
 			Negated:  false
 		}]
-		Order:     0
-		DoNotTrim: false
-		Terminal:  "term1"
-		StepType:  1
-		Name:      "step0"
+		Order:           0
+		InformationOnly: false
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "step0"
 	}
 }
 Hash: "e83870e6a40c0d17db288a9f7b405a090b7ba8e57f4c579d64802268bfa90f45"

--- a/cmd/preguide/testdata/renderers.txt
+++ b/cmd/preguide/testdata/renderers.txt
@@ -177,11 +177,12 @@ Steps: {
 			CmdStr:   "echo -n \"Hello\""
 			Negated:  false
 		}]
-		Order:     0
-		DoNotTrim: false
-		Terminal:  "term1"
-		StepType:  1
-		Name:      "step0"
+		Order:           0
+		InformationOnly: false
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "step0"
 	}
 }
 Hash: "3687cfa919111d3226121f07d207ed7361a74eec5b26028c4fe7c94e1ba633e9"
@@ -228,11 +229,12 @@ Steps: {
 			CmdStr:   "echo -n \"Hello\""
 			Negated:  false
 		}]
-		Order:     0
-		DoNotTrim: false
-		Terminal:  "term1"
-		StepType:  1
-		Name:      "step0"
+		Order:           0
+		InformationOnly: false
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "step0"
 	}
 }
 Hash: "3687cfa919111d3226121f07d207ed7361a74eec5b26028c4fe7c94e1ba633e9"

--- a/cmd/preguide/testdata/runargs.txt
+++ b/cmd/preguide/testdata/runargs.txt
@@ -59,11 +59,12 @@ Steps: {
 			CmdStr:   "echo -n \"The answer is: $GREETING\""
 			Negated:  false
 		}]
-		Order:     0
-		DoNotTrim: false
-		Terminal:  "term1"
-		StepType:  1
-		Name:      "step1"
+		Order:           0
+		InformationOnly: false
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "step1"
 	}
 }
 Hash: "95aec4e582ce6f9172c4e74915228af4bb57485147114ccfee8d24163d516952"

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -68,6 +68,7 @@ Steps: step3: preguide.#Command & {
 }
 
 Steps: step4: preguide.#Command & {
+	InformationOnly: true
 	RandomReplace: "abcdefg123456789"
 	Source: """
 		git rev-parse HEAD
@@ -75,6 +76,7 @@ Steps: step4: preguide.#Command & {
 }
 
 Steps: first_random_commit: preguide.#Command & {
+	InformationOnly: true
 	RandomReplace: "abcd123"
 	Source: """
 		git rev-parse --short HEAD
@@ -96,6 +98,7 @@ Steps: step6: preguide.#Command & {
 }
 
 Steps: second_random_commit: preguide.#Command & {
+	InformationOnly: true
 	RandomReplace: "abcd123"
 	Source: """
 		git rev-parse --short HEAD
@@ -103,6 +106,7 @@ Steps: second_random_commit: preguide.#Command & {
 }
 
 Steps: step7: preguide.#Command & {
+	InformationOnly: true
 	RandomReplace: "abcdefg123456789"
 	Source: """
 		git rev-parse HEAD

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -30,12 +30,11 @@ import "github.com/play-with-go/preguide"
 	Env: [...string]
 }
 
-_#stepCommon: {
+_stepCommon: {
 	StepType: #StepType
 	Name:     string
 	Order:    int
 	Terminal: string
-	...
 }
 
 // TODO: keep this in sync with the Go definitions
@@ -55,10 +54,13 @@ _#stepCommon: {
 	Variables: [...string]
 }
 
-#Step: (#CommandStep | #UploadStep) & _#stepCommon
+#Step: (#CommandStep | #UploadStep) & _stepCommon
 
 #CommandStep: {
-	_#stepCommon
+	_stepCommon
+	DoNotTrim:       bool
+	RandomReplace:   string
+	InformationOnly: bool
 	Stmts: [...#Stmt]
 }
 
@@ -70,7 +72,7 @@ _#stepCommon: {
 }
 
 #UploadStep: {
-	_#stepCommon
+	_stepCommon
 	Renderer: preguide.#Renderer
 	Language: string
 	Source:   string
@@ -145,6 +147,12 @@ import (
 		// should not be trimmed (the default is to trim the trailing \n
 		// from the output) prior to sanitising the output from the script
 		DoNotTrim: *false | bool
+
+		// InformationOnly indicates that this field is not required for the
+		// successful execution of the script. Generally this is used by
+		// command blocks which are outputting random data for post-execution
+		// sanitisation, e.g. git commits.
+		InformationOnly: *false | bool
 	}
 
 	_#uploadCommon: {

--- a/internal/types/guide.go
+++ b/internal/types/guide.go
@@ -123,12 +123,13 @@ type Step interface {
 }
 
 type Command struct {
-	StepTypeVal   StepType `json:"StepType"`
-	Terminal      string
-	Name          string
-	RandomReplace *string
-	DoNotTrim     bool
-	Source        string
+	StepTypeVal     StepType `json:"StepType"`
+	Terminal        string
+	Name            string
+	RandomReplace   *string
+	DoNotTrim       bool
+	InformationOnly bool
+	Source          string
 }
 
 var _ Step = (*Command)(nil)
@@ -138,12 +139,13 @@ func (c *Command) StepType() StepType {
 }
 
 type CommandFile struct {
-	StepTypeVal   StepType `json:"StepType"`
-	Terminal      string
-	Name          string
-	RandomReplace *string
-	DoNotTrim     bool
-	Path          string
+	StepTypeVal     StepType `json:"StepType"`
+	Terminal        string
+	Name            string
+	RandomReplace   *string
+	DoNotTrim       bool
+	InformationOnly bool
+	Path            string
 }
 
 var _ Step = (*CommandFile)(nil)

--- a/out/out.cue
+++ b/out/out.cue
@@ -14,12 +14,11 @@ import "github.com/play-with-go/preguide"
 	Env: [...string]
 }
 
-_#stepCommon: {
+_stepCommon: {
 	StepType: #StepType
 	Name:     string
 	Order:    int
 	Terminal: string
-	...
 }
 
 // TODO: keep this in sync with the Go definitions
@@ -39,10 +38,13 @@ _#stepCommon: {
 	Variables: [...string]
 }
 
-#Step: (#CommandStep | #UploadStep) & _#stepCommon
+#Step: (#CommandStep | #UploadStep) & _stepCommon
 
 #CommandStep: {
-	_#stepCommon
+	_stepCommon
+	DoNotTrim:       bool
+	RandomReplace:   string
+	InformationOnly: bool
 	Stmts: [...#Stmt]
 }
 
@@ -54,7 +56,7 @@ _#stepCommon: {
 }
 
 #UploadStep: {
-	_#stepCommon
+	_stepCommon
 	Renderer: preguide.#Renderer
 	Language: string
 	Source:   string

--- a/preguide.cue
+++ b/preguide.cue
@@ -44,6 +44,12 @@ import (
 		// should not be trimmed (the default is to trim the trailing \n
 		// from the output) prior to sanitising the output from the script
 		DoNotTrim: *false | bool
+
+		// InformationOnly indicates that this field is not required for the
+		// successful execution of the script. Generally this is used by
+		// command blocks which are outputting random data for post-execution
+		// sanitisation, e.g. git commits.
+		InformationOnly: *false | bool
 	}
 
 	_#uploadCommon: {


### PR DESCRIPTION
This allows us to be explicit about which steps are information only.

We also fix up the out schema, and add a sanity check on the out schema
load itself (because of cuelang.org/issue/566)