### PR TITLE
cmd/preguide: HTML escape rendered blocks for jekyll uploads

### DIFF
--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -134,11 +134,11 @@ Hello, world! I am a #CommandFile
 
 <pre data-upload-path="L3NjcmlwdHM=" data-upload-src="c29tZXdoZXJlLnNo:IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWQi" data-upload-term=".term1"><code class="language-sh">#!/usr/bin/env bash
 
-echo "Hello, world! I am an #Upload"</code></pre>
+echo &#34;Hello, world! I am an #Upload&#34;</code></pre>
 
 # Step 4
 
-<pre data-upload-path="L3NjcmlwdHM=" data-upload-src="c3RlcDIuc2g=:ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWRGaWxlIgo=" data-upload-term=".term1"><code class="language-bash">echo "Hello, world! I am an #UploadFile"
+<pre data-upload-path="L3NjcmlwdHM=" data-upload-src="c3RlcDIuc2g=:ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWRGaWxlIgo=" data-upload-term=".term1"><code class="language-bash">echo &#34;Hello, world! I am an #UploadFile&#34;
 </code></pre>
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/en_log.txt.golden --

--- a/cmd/preguide/testdata/parallel.txt
+++ b/cmd/preguide/testdata/parallel.txt
@@ -117,7 +117,7 @@ blah
 
 <pre data-upload-path="L3NjcmlwdHM=" data-upload-src="c29tZXdoZXJlLnNo:IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWQi" data-upload-term=".term1"><code class="language-sh">#!/usr/bin/env bash
 
-echo "Hello, world! I am an #Upload"</code></pre>
+echo &#34;Hello, world! I am an #Upload&#34;</code></pre>
 <script>let pageGuide="myguide1"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide1/en_log.txt.golden --
 Terminals: [
@@ -164,7 +164,7 @@ blah
 
 <pre data-upload-path="L3NjcmlwdHM=" data-upload-src="c29tZXdoZXJlLnNo:IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWQi" data-upload-term=".term1"><code class="language-sh">#!/usr/bin/env bash
 
-echo "Hello, world! I am an #Upload"</code></pre>
+echo &#34;Hello, world! I am an #Upload&#34;</code></pre>
 <script>let pageGuide="myguide2"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide2/en_log.txt.golden --
 Terminals: [

--- a/cmd/preguide/testdata/renderer_diff.txt
+++ b/cmd/preguide/testdata/renderer_diff.txt
@@ -56,6 +56,7 @@ Steps: step2: preguide.#Upload & {
 This is some markdown `with code`
 Another line
 A third line
+<nil>
 
 """
 }
@@ -77,9 +78,10 @@ Hello
 <pre data-upload-path="L2hvbWUvZ29waGVy" data-upload-src="c29tZXdoZXJlLm1k:VGhpcyBpcyBzb21lIG1hcmtkb3duIGB3aXRoIGNvZGVgCg==" data-upload-term=".term1"><code class="language-md">This is some markdown `with code`
 </code></pre>
 
-<pre data-upload-path="L2hvbWUvZ29waGVy" data-upload-src="c29tZXdoZXJlLm1k:VGhpcyBpcyBzb21lIG1hcmtkb3duIGB3aXRoIGNvZGVgCkFub3RoZXIgbGluZQpBIHRoaXJkIGxpbmUK" data-upload-term=".term1"><code class="language-md">This is some markdown `with code`
+<pre data-upload-path="L2hvbWUvZ29waGVy" data-upload-src="c29tZXdoZXJlLm1k:VGhpcyBpcyBzb21lIG1hcmtkb3duIGB3aXRoIGNvZGVgCkFub3RoZXIgbGluZQpBIHRoaXJkIGxpbmUKPG5pbD4K" data-upload-term=".term1"><code class="language-md">This is some markdown `with code`
 <b style="color:darkblue">Another line</b>
 <b style="color:darkblue">A third line</b>
+<b style="color:darkblue">&lt;nil&gt;</b>
 </code></pre>
 
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
@@ -108,6 +110,7 @@ Steps: {
 			This is some markdown `with code`
 			Another line
 			A third line
+			<nil>
 
 			"""
 		Renderer: {
@@ -153,5 +156,5 @@ Steps: {
 		Name:            "step0"
 	}
 }
-Hash: "e83870e6a40c0d17db288a9f7b405a090b7ba8e57f4c579d64802268bfa90f45"
+Hash: "2841b23ef64f8d9cf3fd9f71066788dd07bcb2bec56c6c609070023b33c455fd"
 Delims: ["{{", "}}"]

--- a/cmd/preguide/testdata/sanitise.txt
+++ b/cmd/preguide/testdata/sanitise.txt
@@ -73,10 +73,10 @@ title: A test with output that should be sanitised
 
 <pre data-upload-path="L2hvbWUvZ29waGVy" data-upload-src="aGVsbG8uZ28=:cGFja2FnZSBtYWluCgppbXBvcnQgImZtdCIKCmZ1bmMgbWFpbigpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQhIikKfQ==" data-upload-term=".term1"><code class="language-go">package main
 
-import "fmt"
+import &#34;fmt&#34;
 
 func main() {
-	fmt.Println("Hello, world!")
+	fmt.Println(&#34;Hello, world!&#34;)
 }</code></pre>
 
 # Create test file
@@ -84,12 +84,12 @@ func main() {
 <pre data-upload-path="L2hvbWUvZ29waGVy" data-upload-src="aGVsbG9fdGVzdC5nbw==:cGFja2FnZSBtYWluCgppbXBvcnQgKAoJImZtdCIKCSJ0ZXN0aW5nIgopCgpmdW5jIFRlc3RIZWxsbyh0ICp0ZXN0aW5nLlQpIHsKCWZtdC5QcmludGxuKCJIZWxsbywgd29ybGQuLi4gZnJvbSB0aGUgdGVzdCEiKQp9" data-upload-term=".term1"><code class="language-go">package main
 
 import (
-	"fmt"
-	"testing"
+	&#34;fmt&#34;
+	&#34;testing&#34;
 )
 
 func TestHello(t *testing.T) {
-	fmt.Println("Hello, world... from the test!")
+	fmt.Println(&#34;Hello, world... from the test!&#34;)
 }</code></pre>
 
 # Test

--- a/internal/types/guide.go
+++ b/internal/types/guide.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"text/template"
 
 	"github.com/play-with-go/preguide"
 	"github.com/play-with-go/preguide/internal/textutil"
@@ -252,6 +253,10 @@ func (r *RendererFull) rendererType() RendererType {
 }
 
 func (r *RendererFull) Render(m Mode, v string) (string, error) {
+	switch m {
+	case ModeJekyll:
+		v = template.HTMLEscapeString(v)
+	}
 	return v, nil
 }
 
@@ -288,7 +293,12 @@ func (r *RendererLineRanges) Render(m Mode, v string) (string, error) {
 			res = append(res, r.Ellipsis)
 		}
 	}
-	return strings.Join(res, "\n"), nil
+	result := strings.Join(res, "\n")
+	switch m {
+	case ModeJekyll:
+		result = template.HTMLEscapeString(result)
+	}
+	return result, nil
 }
 
 type RendererDiff struct {
@@ -315,7 +325,12 @@ func (r *RendererDiff) Render(m Mode, v string) (string, error) {
 	after := func(w io.Writer, s string) {
 		fmt.Fprintf(w, "<b style=\"color:darkblue\">%s</b>\n", s)
 	}
-	res := textutil.Diff(r.Pre, v, same, before, after)
+	pre, v := r.Pre, v
+	switch m {
+	case ModeJekyll:
+		pre, v = template.HTMLEscapeString(pre), template.HTMLEscapeString(v)
+	}
+	res := textutil.Diff(pre, v, same, before, after)
 	return res, nil
 }
 


### PR DESCRIPTION
Otherwise we can cause the output to become "funky"

Fixes #134