### PR TITLE
cmd/preguide: include scenario name and language in output guide name

### DIFF
--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -4,22 +4,23 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+exec find -type f
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 # Check that we get a cache hit
 preguide -debug gen -out _output
 ! stdout .+
 stderr '^myguide: cache hit: will not re-run script$'
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 # Verify that when skipping the cache we get the same output
 preguide gen -skipcache -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 -- myguide/en.markdown --
 ---
@@ -96,7 +97,7 @@ Steps: step4: preguide.#UploadFile & {
 echo "Hello, world! I am a #CommandFile"
 -- myguide/step2_uploadFile.sh --
 echo "Hello, world! I am an #UploadFile"
--- myguide/en.markdown.golden --
+-- myguide/go115_en.markdown.golden --
 ---
 guide: myguide
 lang: en
@@ -141,7 +142,7 @@ echo &#34;Hello, world! I am an #Upload&#34;</code></pre>
 <pre data-upload-path="L3NjcmlwdHM=" data-upload-src="c3RlcDIuc2g=:ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGFuICNVcGxvYWRGaWxlIgo=" data-upload-term=".term1"><code class="language-bash">echo &#34;Hello, world! I am an #UploadFile&#34;
 </code></pre>
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en_log.txt.golden --
+-- myguide/go115_en_log.txt.golden --
 Terminals: [
   {
     "Name": "term1",

--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -21,15 +21,15 @@ envsubst conf.cue
 preguide gen -config conf.cue -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 # Run with -raw
 preguide gen -raw -config conf.cue -out _output
 cmp stdout myguide/raw.cue.golden
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.raw.golden
-cmp myguide/en_log.txt myguide/en_log.txt.raw.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.raw.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.raw.golden
 
 -- prestep.txt --
 {
@@ -69,7 +69,7 @@ Terminals: term1: preguide.#Terminal & {
 Steps: step1: preguide.#Command & {Source: """
 echo -n "The answer is: {{.GREETING}}!"
 """}
--- myguide/en.markdown.golden --
+-- myguide/go115_en.markdown.golden --
 ---
 guide: myguide
 lang: en
@@ -83,7 +83,7 @@ The answer is: {% raw %}{{.GREETING}}{% endraw %}!
 ```
 {:data-command-src="ZWNobyAtbiAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en_log.txt.golden --
+-- myguide/go115_en_log.txt.golden --
 Terminals: [
   {
     "Name": "term1",
@@ -150,7 +150,7 @@ Steps: {
 }
 Hash: "e419ad5f6c5f02aa9c78658abb5b4ef480ebc0783a23072224c9c38d8c4ff830"
 Delims: ["{{", "}}"]
--- myguide/en.markdown.raw.golden --
+-- myguide/go115_en.markdown.raw.golden --
 ---
 guide: myguide
 lang: en
@@ -164,7 +164,7 @@ The answer is: Hello, world!!
 ```
 {:data-command-src="ZWNobyAtbiAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en_log.txt.raw.golden --
+-- myguide/go115_en_log.txt.raw.golden --
 Terminals: [
   {
     "Name": "term1",

--- a/cmd/preguide/testdata/github.txt
+++ b/cmd/preguide/testdata/github.txt
@@ -4,7 +4,7 @@
 preguide gen -mode github myguide
 ! stdout .+
 ! stderr .+
-cmp myguide/myguide.markdown myguide/en.markdown.golden
+cmp myguide/myguide_go115_en.markdown myguide/go115_en.markdown.golden
 
 -- myguide/en.markdown --
 ---
@@ -50,7 +50,7 @@ echo "Hello, world! I am an #Upload"
 """
 }
 
--- myguide/en.markdown.golden --
+-- myguide/go115_en.markdown.golden --
 # Step 1
 
 ```

--- a/cmd/preguide/testdata/limitations.txt
+++ b/cmd/preguide/testdata/limitations.txt
@@ -5,7 +5,7 @@
 # hence non-English langage guide should fail
 ! preguide gen -out demarkdown/_output -dir demarkdown
 ! stdout .+
-stderr 'demarkdown/guide: we only support English language guides for now'
+stderr 'demarkdown/guide/de.markdown: "de" is not a valid language for this guide'
 
 # Only support English language guides for now (hence a single language)
 # hence non-English steps should fail
@@ -33,6 +33,16 @@ stderr 'input markdown and output from script blocks cannot contain \\{%'
 ---
 title: Test
 ---
+-- demarkdown/guide/guide.cue --
+package guide
+
+import "github.com/play-with-go/preguide"
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
 -- desteps/guide/en.markdown --
 ---
 title: Test

--- a/cmd/preguide/testdata/missing_step.txt
+++ b/cmd/preguide/testdata/missing_step.txt
@@ -4,6 +4,16 @@
 ! stdout .+
 stderr '^myguide/en.md:9:1: unknown step "step1" referened$'
 
+-- myguide/guide.cue --
+package guide
+
+import "github.com/play-with-go/preguide"
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
 -- myguide/en.md --
 ---
 layout: rubbish

--- a/cmd/preguide/testdata/no_directives.txt
+++ b/cmd/preguide/testdata/no_directives.txt
@@ -4,7 +4,11 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.md myguide/en.md.golden
+exec find -type f
+cmp _output/myguide_en.md myguide/en.md.golden
+
+-- myguide/guide.cue --
+package guide
 
 -- myguide/en.md --
 ---

--- a/cmd/preguide/testdata/non_english_guide.txt
+++ b/cmd/preguide/testdata/non_english_guide.txt
@@ -2,7 +2,10 @@
 # a markdown file
 
 ! preguide gen -out _output
-stderr 'we only support English language guides for now'
+stderr 'myguide/es.md: "es" is not a valid language for this guide'
+
+-- myguide/guide.cue --
+package guide
 
 -- myguide/en.md --
 ---

--- a/cmd/preguide/testdata/out_refs.txt
+++ b/cmd/preguide/testdata/out_refs.txt
@@ -3,7 +3,7 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.md myguide/en.md.golden
+cmp _output/myguide_go115_en.md myguide/go115_en.md.golden
 
 -- myguide/en.md --
 ---
@@ -56,7 +56,7 @@ Defs: {
 	echo_out:         Steps.step1.Stmts[0].Output
 	cmd_false:        Steps.step1.Stmts[2].CmdStr
 }
--- myguide/en.md.golden --
+-- myguide/go115_en.md.golden --
 ---
 guide: myguide
 lang: en

--- a/cmd/preguide/testdata/parallel.txt
+++ b/cmd/preguide/testdata/parallel.txt
@@ -4,10 +4,10 @@
 preguide gen -parallel 2 -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide1.markdown myguide1/en.markdown.golden
-cmp _output/myguide2.markdown myguide2/en.markdown.golden
-cmp myguide1/en_log.txt myguide1/en_log.txt.golden
-cmp myguide2/en_log.txt myguide2/en_log.txt.golden
+cmp _output/myguide1_go115_en.markdown myguide1/go115_en.markdown.golden
+cmp _output/myguide2_go115_en.markdown myguide2/go115_en.markdown.golden
+cmp myguide1/go115_en_log.txt myguide1/go115_en_log.txt.golden
+cmp myguide2/go115_en_log.txt myguide2/go115_en_log.txt.golden
 
 -- myguide1/en.markdown --
 ---
@@ -95,7 +95,7 @@ echo "Hello, world! I am an #Upload"
 """
 }
 
--- myguide1/en.markdown.golden --
+-- myguide1/go115_en.markdown.golden --
 ---
 guide: myguide1
 lang: en
@@ -119,7 +119,7 @@ blah
 
 echo &#34;Hello, world! I am an #Upload&#34;</code></pre>
 <script>let pageGuide="myguide1"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide1/en_log.txt.golden --
+-- myguide1/go115_en_log.txt.golden --
 Terminals: [
   {
     "Name": "term1",
@@ -142,7 +142,7 @@ $ cat <<EOD > /scripts/somewhere.sh
 
 echo "Hello, world! I am an #Upload"
 EOD
--- myguide2/en.markdown.golden --
+-- myguide2/go115_en.markdown.golden --
 ---
 guide: myguide2
 lang: en
@@ -166,7 +166,7 @@ blah
 
 echo &#34;Hello, world! I am an #Upload&#34;</code></pre>
 <script>let pageGuide="myguide2"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide2/en_log.txt.golden --
+-- myguide2/go115_en_log.txt.golden --
 Terminals: [
   {
     "Name": "term1",

--- a/cmd/preguide/testdata/prestep.txt
+++ b/cmd/preguide/testdata/prestep.txt
@@ -19,24 +19,24 @@ cp version.1 version
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 cmp gen_guide_structures.cue gen_guide_structures.cue.golden
 
 # Check that we get a cache hit
 preguide -debug gen -out _output
 ! stdout .+
 stderr '^myguide: cache hit: will not re-run script$'
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 # Verify that changing the prestep causes a new output
 cp version.2 version
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.other.golden
-cmp myguide/en_log.txt myguide/en_log.txt.other.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.other.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.other.golden
 
 # Now do docker tests by running the server in a docker container.
 # Because this involves running ourselves, we need to set the
@@ -47,8 +47,8 @@ cp conf.docker.cue conf.cue
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 -- go.mod --
 module mod.com/init
@@ -110,7 +110,7 @@ Terminals: term1: preguide.#Terminal & {
 Steps: step1: preguide.#Command & {Source: """
 echo "The answer is: {{.GREETING}}!"
 """}
--- myguide/en.markdown.golden --
+-- myguide/go115_en.markdown.golden --
 ---
 guide: myguide
 lang: en
@@ -124,7 +124,7 @@ The answer is: {% raw %}{{.GREETING}}{% endraw %}!
 ```
 {:data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en_log.txt.golden --
+-- myguide/go115_en_log.txt.golden --
 Terminals: [
   {
     "Name": "term1",
@@ -151,7 +151,7 @@ Presteps: [
 ]
 $ echo "The answer is: {{.GREETING}}!"
 The answer is: {{.GREETING}}!
--- myguide/en.markdown.other.golden --
+-- myguide/go115_en.markdown.other.golden --
 ---
 guide: myguide
 lang: en
@@ -165,7 +165,7 @@ The answer is: {% raw %}{{.GREETING}}{% endraw %}!
 ```
 {:data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en_log.txt.other.golden --
+-- myguide/go115_en_log.txt.other.golden --
 Terminals: [
   {
     "Name": "term1",

--- a/cmd/preguide/testdata/prestep_file.txt
+++ b/cmd/preguide/testdata/prestep_file.txt
@@ -10,8 +10,8 @@ envsubst conf.cue
 preguide gen -config conf.cue -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 -- prestep.txt --
 {
@@ -53,7 +53,7 @@ Terminals: term1: preguide.#Terminal & {
 Steps: step1: preguide.#Command & {Source: """
 echo "The answer is: {{{.GREETING}}}!"
 """}
--- myguide/en.markdown.golden --
+-- myguide/go115_en.markdown.golden --
 ---
 guide: myguide
 lang: en
@@ -67,7 +67,7 @@ The answer is: {% raw %}{{{.GREETING}}}{% endraw %}!
 ```
 {:data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3t7LkdSRUVUSU5HfX19ISIK"}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en_log.txt.golden --
+-- myguide/go115_en_log.txt.golden --
 Terminals: [
   {
     "Name": "term1",

--- a/cmd/preguide/testdata/refs.txt
+++ b/cmd/preguide/testdata/refs.txt
@@ -3,7 +3,7 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.md myguide/en.md.golden
+cmp _output/myguide_en.md myguide/en.md.golden
 
 -- myguide/en.md --
 ---

--- a/cmd/preguide/testdata/renderer_diff.txt
+++ b/cmd/preguide/testdata/renderer_diff.txt
@@ -4,7 +4,7 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
 cmp myguide/out/gen_out.cue myguide/out/gen_out.cue.golden
 
 -- myguide/en.markdown --
@@ -61,7 +61,7 @@ A third line
 """
 }
 
--- myguide/en.markdown.golden --
+-- myguide/go115_en.markdown.golden --
 ---
 guide: myguide
 lang: en

--- a/cmd/preguide/testdata/renderers.txt
+++ b/cmd/preguide/testdata/renderers.txt
@@ -5,14 +5,14 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en_pre.markdown.golden
+cmp _output/myguide_go115_en.markdown myguide/pre.go115_en_markdown.golden
 cmp myguide/out/gen_out.cue myguide/out/gen_out_pre.cue.golden
 
 # Check that we get a cache hit second time around
 preguide -debug gen -out _output
 ! stdout .+
 stderr '^myguide: cache hit: will not re-run script$'
-cmp _output/myguide.markdown myguide/en_pre.markdown.golden
+cmp _output/myguide_go115_en.markdown myguide/pre.go115_en_markdown.golden
 cmp myguide/out/gen_out.cue myguide/out/gen_out_pre.cue.golden
 
 # Change the renderertype and ensure we get a cache hit but
@@ -21,7 +21,7 @@ cp myguide/steps.cue.changed myguide/steps.cue
 preguide -debug gen -out _output
 ! stdout .+
 stderr '^myguide: cache hit: will not re-run script$'
-cmp _output/myguide.markdown myguide/en_post.markdown.golden
+cmp _output/myguide_go115_en.markdown myguide/post.go115_en_markdown.golden
 cmp myguide/out/gen_out.cue myguide/out/gen_out_post.cue.golden
 
 -- myguide/en.markdown --
@@ -97,7 +97,7 @@ A third line
 """
 }
 
--- myguide/en_pre.markdown.golden --
+-- myguide/pre.go115_en_markdown.golden --
 ---
 guide: myguide
 lang: en
@@ -116,7 +116,7 @@ Another line
 A third line</code></pre>
 
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en_post.markdown.golden --
+-- myguide/post.go115_en_markdown.golden --
 ---
 guide: myguide
 lang: en

--- a/cmd/preguide/testdata/run.txt
+++ b/cmd/preguide/testdata/run.txt
@@ -6,51 +6,56 @@ rm _output/run2.markdown
 
 # Run only 1
 preguide gen -run 1 -out _output
-exists _output/run1.markdown
-! exists _output/run2.markdown
+exists _output/run1_en.markdown
+! exists _output/run2_en.markdown
 
 # Tidy up (all, regardless of whether they exist)
-rm _output/run1.markdown
-rm _output/run2.markdown
+rm _output/run1_en.markdown
+rm _output/run2_en.markdown
 
 # Run only 2
 preguide gen -run 2 -out _output
-! exists _output/run1.markdown
-exists _output/run2.markdown
+! exists _output/run1_en.markdown
+exists _output/run2_en.markdown
 
 # Tidy up (all, regardless of whether they exist)
-rm _output/run1.markdown
-rm _output/run2.markdown
+rm _output/run1_en.markdown
+rm _output/run2_en.markdown
 
 # Run all
 preguide gen -run . -out _output
-exists _output/run1.markdown
-exists _output/run2.markdown
+exists _output/run1_en.markdown
+exists _output/run2_en.markdown
 
 # Tidy up (all, regardless of whether they exist)
-rm _output/run1.markdown
-rm _output/run2.markdown
+rm _output/run1_en.markdown
+rm _output/run2_en.markdown
 
 # Run only 1 via PREGUIDE_RUN
 env PREGUIDE_RUN=1
 preguide gen -out _output
-exists _output/run1.markdown
-! exists _output/run2.markdown
+exists _output/run1_en.markdown
+! exists _output/run2_en.markdown
 
 # Tidy up (all, regardless of whether they exist)
-rm _output/run1.markdown
-rm _output/run2.markdown
+rm _output/run1_en.markdown
+rm _output/run2_en.markdown
 
 # Run all by overriding preguide via -run
 preguide gen -run . -out _output
-exists _output/run1.markdown
-exists _output/run2.markdown
+exists _output/run1_en.markdown
+exists _output/run2_en.markdown
 
+-- run1/steps.cue --
+package steps
 
 -- run1/en.markdown --
 ---
 title: Test
 ---
+-- run2/steps.cue --
+package steps
+
 -- run2/en.markdown --
 ---
 title: Test

--- a/cmd/preguide/testdata/sanitise.txt
+++ b/cmd/preguide/testdata/sanitise.txt
@@ -4,8 +4,8 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 -- myguide/en.markdown --
 ---
@@ -63,7 +63,7 @@ Steps: step3: preguide.#Command & { Source: """
 go test
 """}
 
--- myguide/en.markdown.golden --
+-- myguide/go115_en.markdown.golden --
 ---
 guide: myguide
 lang: en
@@ -102,7 +102,7 @@ ok  	_/home/gopher	0.042s
 ```
 {:data-command-src="Z28gdGVzdAo="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en_log.txt.golden --
+-- myguide/go115_en_log.txt.golden --
 Terminals: [
   {
     "Name": "term1",

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -5,8 +5,8 @@
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide.markdown myguide/en.markdown.golden
-cmp myguide/en_log.txt myguide/en_log.txt.golden
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 -- go.mod --
 module mod.com/init
@@ -113,7 +113,7 @@ Steps: step7: preguide.#Command & {
 		"""
 }
 
--- myguide/en.markdown.golden --
+-- myguide/go115_en.markdown.golden --
 ---
 guide: myguide
 lang: en
@@ -161,7 +161,7 @@ abcdefg123456789
 ```
 {:data-command-src="Z2l0IHJldi1wYXJzZSBIRUFECg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
--- myguide/en_log.txt.golden --
+-- myguide/go115_en_log.txt.golden --
 Terminals: [
   {
     "Name": "term1",

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -220,8 +220,8 @@ import (
 
 	// Scenarios define the various images under which this guide will be
 	// run
-	Scenarios: [string]: #Scenario
-	Scenarios: [name=string]: {
+	_#ScenarioName: =~"^[a-zA-Z0-9]+$"
+	Scenarios: [name=_#ScenarioName]: #Scenario & {
 		Name: name
 	}
 

--- a/preguide.cue
+++ b/preguide.cue
@@ -117,8 +117,8 @@ import (
 
 	// Scenarios define the various images under which this guide will be
 	// run
-	Scenarios: [string]: #Scenario
-	Scenarios: [name=string]: {
+	_#ScenarioName: =~"^[a-zA-Z0-9]+$"
+	Scenarios: [name=_#ScenarioName]: #Scenario & {
 		Name: name
 	}
 


### PR DESCRIPTION
This ensures that we will not break existing guide URLs when we start to
support different scenarios and languages in the future.

This also limits the format of a scenario name.