### PR TITLE
cmd/preguide: do not write presteps and terminals to a guide log

### DIFF
--- a/cmd/preguide/guide.go
+++ b/cmd/preguide/guide.go
@@ -252,10 +252,6 @@ func (pdc *processDirContext) writeLog() {
 	// one language and one scenario if we steps, else we have zero scenarios
 
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "Terminals: %s\n", mustJSONMarshalIndent(g.Terminals))
-	if len(g.Presteps) > 0 {
-		fmt.Fprintf(&buf, "Presteps: %s\n", mustJSONMarshalIndent(g.Presteps))
-	}
 	for _, step := range g.steps {
 		step.renderLog(pdc.fMode, &buf)
 	}

--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -143,17 +143,6 @@ echo &#34;Hello, world! I am an #Upload&#34;</code></pre>
 </code></pre>
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/go115_en_log.txt.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
 $ mkdir nooutput
 $ echo "Hello, world! I am a #Command"
 Hello, world! I am a #Command

--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -84,28 +84,6 @@ The answer is: {% raw %}{{.GREETING}}{% endraw %}!
 {:data-command-src="ZWNobyAtbiAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/go115_en_log.txt.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
-Presteps: [
-  {
-    "Package": "github.com/blah",
-    "Path": "/",
-    "Args": null,
-    "Version": "file",
-    "Variables": [
-      "GREETING"
-    ]
-  }
-]
 $ echo -n "The answer is: {{.GREETING}}!"
 The answer is: {{.GREETING}}!
 -- myguide/raw.cue.golden --
@@ -165,27 +143,5 @@ The answer is: Hello, world!!
 {:data-command-src="ZWNobyAtbiAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/go115_en_log.txt.raw.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
-Presteps: [
-  {
-    "Package": "github.com/blah",
-    "Path": "/",
-    "Args": null,
-    "Version": "file",
-    "Variables": [
-      "GREETING"
-    ]
-  }
-]
 $ echo -n "The answer is: {{.GREETING}}!"
 The answer is: Hello, world!!

--- a/cmd/preguide/testdata/parallel.txt
+++ b/cmd/preguide/testdata/parallel.txt
@@ -120,17 +120,6 @@ blah
 echo &#34;Hello, world! I am an #Upload&#34;</code></pre>
 <script>let pageGuide="myguide1"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide1/go115_en_log.txt.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
 $ echo "Hello, world! I am a #Command"
 Hello, world! I am a #Command
 $ touch blah
@@ -167,17 +156,6 @@ blah
 echo &#34;Hello, world! I am an #Upload&#34;</code></pre>
 <script>let pageGuide="myguide2"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide2/go115_en_log.txt.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
 $ echo "Hello, world! I am a #Command"
 Hello, world! I am a #Command
 $ touch blah

--- a/cmd/preguide/testdata/prestep.txt
+++ b/cmd/preguide/testdata/prestep.txt
@@ -125,30 +125,6 @@ The answer is: {% raw %}{{.GREETING}}{% endraw %}!
 {:data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/go115_en_log.txt.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
-Presteps: [
-  {
-    "Package": "github.com/blah",
-    "Path": "/somewhere",
-    "Args": {
-      "Message": "Hello, world!"
-    },
-    "Version": "1",
-    "Variables": [
-      "GREETING"
-    ]
-  }
-]
 $ echo "The answer is: {{.GREETING}}!"
 The answer is: {{.GREETING}}!
 -- myguide/go115_en.markdown.other.golden --
@@ -166,30 +142,6 @@ The answer is: {% raw %}{{.GREETING}}{% endraw %}!
 {:data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/go115_en_log.txt.other.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
-Presteps: [
-  {
-    "Package": "github.com/blah",
-    "Path": "/somewhere",
-    "Args": {
-      "Message": "Hello, world!"
-    },
-    "Version": "2",
-    "Variables": [
-      "GREETING"
-    ]
-  }
-]
 $ echo "The answer is: {{.GREETING}}!"
 The answer is: {{.GREETING}}!
 -- prestep_server.go --

--- a/cmd/preguide/testdata/prestep_file.txt
+++ b/cmd/preguide/testdata/prestep_file.txt
@@ -68,27 +68,5 @@ The answer is: {% raw %}{{{.GREETING}}}{% endraw %}!
 {:data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3t7LkdSRUVUSU5HfX19ISIK"}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/go115_en_log.txt.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
-Presteps: [
-  {
-    "Package": "github.com/blah",
-    "Path": "/",
-    "Args": null,
-    "Version": "file",
-    "Variables": [
-      "GREETING"
-    ]
-  }
-]
 $ echo "The answer is: {{{.GREETING}}}!"
 The answer is: {{{.GREETING}}}!

--- a/cmd/preguide/testdata/sanitise.txt
+++ b/cmd/preguide/testdata/sanitise.txt
@@ -103,17 +103,6 @@ ok  	_/home/gopher	0.042s
 {:data-command-src="Z28gdGVzdAo="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/go115_en_log.txt.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
 $ cat <<EOD > /home/gopher/hello.go
 package main
 

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -162,17 +162,6 @@ abcdefg123456789
 {:data-command-src="Z2l0IHJldi1wYXJzZSBIRUFECg=="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
 -- myguide/go115_en_log.txt.golden --
-Terminals: [
-  {
-    "Name": "term1",
-    "Description": "The main terminal",
-    "Scenarios": {
-      "go115": {
-        "Image": "this_will_never_be_used"
-      }
-    }
-  }
-]
 $ mkdir example
 $ cd example
 $ git init


### PR DESCRIPTION
Whilst this important detail for a guide, it is included in the
generated out package for a guide. The log is meant to be human
readable. And it is meant to be a quick way of determining how the
output of a guide has changed. Therefore, to include version information
in these files makes the diff too noisy; you always end up ignorning the
part of the diff that relates to version information, which means that
the signal to noise ratio is too low. Hence these diffs start to be
ignored.