### PR TITLE
cmd/preguide: do not hardcode the diff renderer highlight colour

### DIFF
--- a/cmd/preguide/testdata/renderer_diff.txt
+++ b/cmd/preguide/testdata/renderer_diff.txt
@@ -79,9 +79,9 @@ Hello
 </code></pre>
 
 <pre data-upload-path="L2hvbWUvZ29waGVy" data-upload-src="c29tZXdoZXJlLm1k:VGhpcyBpcyBzb21lIG1hcmtkb3duIGB3aXRoIGNvZGVgCkFub3RoZXIgbGluZQpBIHRoaXJkIGxpbmUKPG5pbD4K" data-upload-term=".term1"><code class="language-md">This is some markdown `with code`
-<b style="color:darkblue">Another line</b>
-<b style="color:darkblue">A third line</b>
-<b style="color:darkblue">&lt;nil&gt;</b>
+<b>Another line</b>
+<b>A third line</b>
+<b>&lt;nil&gt;</b>
 </code></pre>
 
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>

--- a/internal/types/guide.go
+++ b/internal/types/guide.go
@@ -323,7 +323,7 @@ func (r *RendererDiff) Render(m Mode, v string) (string, error) {
 	}
 	before := func(w io.Writer, s string) {}
 	after := func(w io.Writer, s string) {
-		fmt.Fprintf(w, "<b style=\"color:darkblue\">%s</b>\n", s)
+		fmt.Fprintf(w, "<b>%s</b>\n", s)
 	}
 	pre, v := r.Pre, v
 	switch m {


### PR DESCRIPTION
In PWG we will use styling to ensure the font style is correct.