### PR TITLE
cmd/preguide: support printing of progress via PREGUIDE_PROGRESS=true

### DIFF
--- a/cmd/preguide/testdata/progress.txt
+++ b/cmd/preguide/testdata/progress.txt
@@ -1,0 +1,33 @@
+# Test that we get progress output when requested
+
+env PREGUIDE_PROGRESS=true
+
+preguide gen -out _output
+stdout '^myguide: \$ echo "Hello, world!"$'
+stdout '^myguide: Hello, world!$'
+stdout '^myguide: 0$'
+! stderr .+
+
+-- myguide/en.markdown --
+---
+title: myguide
+---
+
+<!--step: step1 -->
+-- myguide/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Scenarios: go115: {
+	Description: "Go 1.15"
+}
+
+Steps: step1: preguide.#Command & {Source: """
+echo "Hello, world!"
+"""}


### PR DESCRIPTION
This is useful when running individual, long-running scripts like the
PWG retract example.