### PR TITLE
cmd/preguide: sanitise output from go get which includes mod VCS path

### DIFF
--- a/sanitisers/cmdgo/go.go
+++ b/sanitisers/cmdgo/go.go
@@ -17,11 +17,15 @@ import (
 const (
 	goTestTestTime  = `\d+(\.\d+)?s`
 	goTestMagicTime = `0.042s`
+
+	goGetModVCSPathMagic = "0123456789abcdef"
 )
 
 var (
 	goTestPassRunHeading = regexp.MustCompile(`^( *--- (PASS|FAIL): .+\()` + goTestTestTime + `\)$`)
 	goTestFailSummary    = regexp.MustCompile(`^((FAIL|ok  )\t.+\t)` + goTestTestTime + `$`)
+
+	goGetModVCSPath = regexp.MustCompile(`(pkg/mod/cache/vcs/)[0-9a-f]+`)
 )
 
 func CmdGoStmtSanitiser(s *sanitisers.S, stmt *syntax.Stmt) sanitisers.Sanitiser {
@@ -52,6 +56,10 @@ func (sanitiseGoTest) ComparisonOutput(varNames []string, s string) string {
 type sanitiseGoGet struct{}
 
 func (sanitiseGoGet) Output(varNames []string, s string) string {
+	// If we ever see something that looks like it's from the module vcs cache
+	// sanitise that to something standard.. because there is no command that
+	// can be run to list that path
+	s = goGetModVCSPath.ReplaceAllString(s, fmt.Sprintf("${1}%v", goGetModVCSPathMagic))
 	return s
 }
 

--- a/sanitisers/cmdgo/go_test.go
+++ b/sanitisers/cmdgo/go_test.go
@@ -9,14 +9,18 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/play-with-go/preguide/sanitisers"
 )
 
 func TestSanitiseOutputGoTest(t *testing.T) {
 	testCases := []struct {
+		san  sanitisers.Sanitiser
 		in   string
 		want string
-	}{{
-		in: `=== RUN   TestGood
+	}{
+		{
+			san: sanitiseGoTest{},
+			in: `=== RUN   TestGood
 === RUN   TestGood/something
 ok
 --- PASS: TestGood (0.00s)
@@ -35,7 +39,7 @@ FAIL
 FAIL	 mod.go/p 	0.002s
 FAIL
 `,
-		want: `=== RUN   TestGood
+			want: `=== RUN   TestGood
 === RUN   TestGood/something
 ok
 --- PASS: TestGood (0.042s)
@@ -54,10 +58,28 @@ FAIL
 FAIL	 mod.go/p 	0.042s
 FAIL
 `,
-	}}
+		},
+		{
+			san: sanitiseGoGet{},
+			in: `go get example.com/private: module example.com/private: reading https://proxy.golang.org/example.com/private/@v/list: 410 Gone
+	server response:
+	not found: module example.com/private: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/21d3ff96908bdf3e8553891caf86061ba84ba5b6ea4700a65e79b3d3e38384e9: exit status 128:
+		fatal: could not read Username for 'https://gopher.live': terminal prompts disabled
+	Confirm the import path was entered correctly.
+	If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
+`,
+			want: `go get example.com/private: module example.com/private: reading https://proxy.golang.org/example.com/private/@v/list: 410 Gone
+	server response:
+	not found: module example.com/private: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
+		fatal: could not read Username for 'https://gopher.live': terminal prompts disabled
+	Confirm the import path was entered correctly.
+	If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
+`,
+		},
+	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("TestSanitiseOuputGoTest_%v", i), func(t *testing.T) {
-			var san sanitiseGoTest
+			san := tc.san
 			got := san.Output(nil, tc.in)
 			if got != tc.want {
 				t.Fatalf("failed to get sanitised output: %v", cmp.Diff(got, tc.want))
@@ -70,18 +92,20 @@ func TestSanitiseComparisonOutputGoGet(t *testing.T) {
 	testCases := []struct {
 		in   string
 		want string
-	}{{
-		in: `go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
+	}{
+		{
+			in: `go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
 go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
 go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 go: downloading golang.org/x/mod v0.3.0
 `,
-		want: `
+			want: `
 go: downloading golang.org/x/mod v0.3.0
 go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
 go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360`,
-	}}
+		},
+	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("TestSanitiseComparisonOutputGoGet_%v", i), func(t *testing.T) {
 			var san sanitiseGoGet


### PR DESCRIPTION
We can't list the output using the Go command. It's not really very
interesting, but we do see it when getting a private module fails