### PR TITLE
cmd/preguide: add cmpregex

### DIFF
--- a/cmd/preguide/splitaroundvars_test.go
+++ b/cmd/preguide/splitaroundvars_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSplitAroundVars(t *testing.T) {
+	vs := []struct {
+		in  string
+		out []string
+	}{
+		{"", []string{""}},
+		{"test", []string{"test"}},
+		{"$test", []string{"", "test", ""}},
+		{"${test}", []string{"", "test", ""}},
+		{"${}", []string{"${}"}},
+		{"$ test", []string{"$ test"}},
+		{"$ test $var", []string{"$ test ", "var", ""}},
+		{"${ test}", []string{"", " test", ""}},
+		{"${regex_float}hello$ go test", []string{"", "regex_float", "hello$ go test"}},
+		{"term1$ go test${regex_float}s", []string{"term1$ go test", "regex_float", "s"}},
+	}
+	for _, v := range vs {
+		got := splitAroundVars(v.in)
+		if !cmp.Equal(got, v.out) {
+			t.Fatalf("splitAroundVars(%q): %v", v.in, cmp.Diff(got, v.out))
+		}
+	}
+}
+
+func splitAroundVars(s string) (parts []string) {
+	// ${} is all ASCII, so bytes are fine for this operation.
+	i := 0
+	for j := 0; j < len(s); j++ {
+		if s[j] == '$' && j+1 < len(s) {
+			name, w := getShellName(s[j+1:])
+			if name != "" {
+				parts = append(parts, string(s[i:j]), name)
+				i = j + w + 1 // the +1 is the dollar
+			}
+			j += w // the +1 for the dollar is added in the for loop
+		}
+	}
+	if len(parts) == 0 {
+		return []string{s}
+	}
+	parts = append(parts, s[i:])
+	return parts
+}
+
+// getShellName returns the name that begins the string and the number of bytes
+// consumed to extract it. If the name is enclosed in {}, it's part of a ${}
+// expansion and two more bytes are needed than the length of the name.
+func getShellName(s string) (string, int) {
+	switch {
+	case s[0] == '{':
+		if len(s) > 2 && isShellSpecialVar(s[1]) && s[2] == '}' {
+			return s[1:2], 3
+		}
+		// Scan to closing brace
+		for i := 1; i < len(s); i++ {
+			if s[i] == '}' {
+				if i == 1 {
+					return "", 2 // Bad syntax; eat "${}"
+				}
+				return s[1:i], i + 1
+			}
+		}
+		return "", 1 // Bad syntax; eat "${"
+	case isShellSpecialVar(s[0]):
+		return s[0:1], 1
+	}
+	// Scan alphanumerics.
+	var i int
+	for i = 0; i < len(s) && isAlphaNum(s[i]); i++ {
+	}
+	return s[:i], i
+}
+
+func isShellSpecialVar(c uint8) bool {
+	switch c {
+	case '*', '#', '$', '@', '!', '?', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return true
+	}
+	return false
+}
+
+func isAlphaNum(c uint8) bool {
+	return c == '_' || '0' <= c && c <= '9' || 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z'
+}

--- a/cmd/preguide/testdata/cmpregex.txt
+++ b/cmd/preguide/testdata/cmpregex.txt
@@ -1,0 +1,43 @@
+# Test that cmpregex actually works
+
+env float='\d(\.\d+)?'
+
+# Success
+cmd-cmpregex a a.golden
+
+# Failure
+! cmd-cmpregex b b.golden
+cmp stderr b.stderr
+
+# TODO: add more cases
+
+-- a --
+$ go test
+Hello, world... from the test!
+PASS
+ok         _/home/gopher   0.042s
+-- a.golden --
+$ go test
+Hello, world... from the test!
+PASS
+ok         _/home/gopher   ${float}s
+-- b --
+$ go test
+ello, world... from the test!
+PASS
+ok         _/home/gopher   0.042s
+-- b.golden --
+$ go test
+Hello, world... from the test!
+PASS
+ok         _/home/gopher   ${float}s
+-- b.stderr --
+[diff -b +b.golden]
+ $ go test
+-ello, world... from the test!
++Hello, world... from the test!
+ PASS
+-ok         _/home/gopher   0.042s
++ok         _/home/gopher   
+
+b and b.golden differ

--- a/cmd/preguide/testdata/sanitise.txt
+++ b/cmd/preguide/testdata/sanitise.txt
@@ -1,11 +1,15 @@
 # Test that we get the expected output when a step involves
 # output that should sanitised
 
+env regex_float='\d+(?:\.\d+)?'
+env regex_int='\d+'
+env regex_space='\s+'
+
 preguide gen -out _output
 ! stdout .+
 ! stderr .+
-cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
-cmp myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
+cmpregex _output/myguide_go115_en.markdown myguide/go115_en.markdown.golden
+cmpregex myguide/go115_en_log.txt myguide/go115_en_log.txt.golden
 
 -- myguide/en.markdown --
 ---
@@ -98,7 +102,7 @@ func TestHello(t *testing.T) {
 $ go test
 Hello, world... from the test!
 PASS
-ok  	_/home/gopher	0.042s
+ok  	_/home/gopher	${regex_float}s
 ```
 {:data-command-src="Z28gdGVzdAo="}
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
@@ -127,4 +131,4 @@ EOD
 $ go test
 Hello, world... from the test!
 PASS
-ok  	_/home/gopher	0.042s
+ok${regex_space}_/home/gopher${regex_space}${regex_float}s

--- a/internal/textutil/diff.go
+++ b/internal/textutil/diff.go
@@ -15,7 +15,7 @@ import (
 // additions and removals to turn text1 into text2.
 // (That is, lines only in text1 appear with a leading -,
 // and lines only in text2 appear with a leading +.)
-func Diff(text1, text2 string, same, before, after func(io.Writer, string)) string {
+func Diff(text1, text2 string, mark bool, same, before, after func(io.Writer, string)) string {
 	if text1 != "" && !strings.HasSuffix(text1, "\n") {
 		text1 += "(missing final newline)"
 	}
@@ -69,19 +69,28 @@ func Diff(text1, text2 string, same, before, after func(io.Writer, string)) stri
 		after = stringIdentity
 	}
 
+	sameMark := ""
+	beforeMark := ""
+	afterMark := ""
+	if mark {
+		sameMark = " "
+		beforeMark = "-"
+		afterMark = "+"
+	}
+
 	var buf strings.Builder
 	i, j := len(lines1), len(lines2)
 	for i > 0 || j > 0 {
 		cost := dist[i][j]
 		if i > 0 && j > 0 && cost == dist[i-1][j-1] && lines1[len(lines1)-i] == lines2[len(lines2)-j] {
-			same(&buf, lines1[len(lines1)-i])
+			same(&buf, sameMark+lines1[len(lines1)-i])
 			i--
 			j--
 		} else if i > 0 && cost == dist[i-1][j]+1 {
-			before(&buf, lines1[len(lines1)-i])
+			before(&buf, beforeMark+lines1[len(lines1)-i])
 			i--
 		} else {
-			after(&buf, lines2[len(lines2)-j])
+			after(&buf, afterMark+lines2[len(lines2)-j])
 			j--
 		}
 	}

--- a/internal/textutil/diff_test.go
+++ b/internal/textutil/diff_test.go
@@ -46,7 +46,7 @@ func TestDiff(t *testing.T) {
 		after := func(w io.Writer, s string) {
 			fmt.Fprintf(w, "+%s\n", s)
 		}
-		out := textutil.Diff(text1, text2, same, before, after)
+		out := textutil.Diff(text1, text2, false, same, before, after)
 		// Cut final \n, cut spaces, turn remaining \n into spaces.
 		out = strings.Replace(strings.Replace(strings.TrimSuffix(out, "\n"), " ", "", -1), "\n", " ", -1)
 		if out != tt.diff {

--- a/internal/types/guide.go
+++ b/internal/types/guide.go
@@ -330,7 +330,7 @@ func (r *RendererDiff) Render(m Mode, v string) (string, error) {
 	case ModeJekyll:
 		pre, v = template.HTMLEscapeString(pre), template.HTMLEscapeString(v)
 	}
-	res := textutil.Diff(pre, v, same, before, after)
+	res := textutil.Diff(pre, v, false, same, before, after)
 	return res, nil
 }
 


### PR DESCRIPTION
Similar to cmpenv, except that environment variable values are
interpretted as regular expressions.