### PR TITLE
cmd/preguide: HTML sanitise command blocks

### DIFF
--- a/cmd/preguide/step.go
+++ b/cmd/preguide/step.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"path"
 	"strings"
+	"text/template"
 
 	"github.com/play-with-go/preguide/internal/types"
 	"github.com/play-with-go/preguide/sanitisers"
@@ -211,8 +212,8 @@ func (c *commandStep) render(w io.Writer, opts renderOptions) {
 			fmt.Fprintf(enc, "%s\n", stmt.CmdStr)
 			// replaceBraces is safe to do here because in all modes we are
 			// outputting <pre><code> blocks
-			fmt.Fprintf(&cmds, "$ %s\n", replaceBraces(stmt.CmdStr))
-			fmt.Fprintf(&cmds, "%s", replaceBraces(stmt.Output))
+			fmt.Fprintf(&cmds, "$ %s\n", stmt.CmdStr)
+			fmt.Fprintf(&cmds, "%s", stmt.Output)
 		}
 		// Output a trailing newline if the last block of output did not include one
 		// otherwise the closing code block fence will not render properly
@@ -229,7 +230,10 @@ func (c *commandStep) render(w io.Writer, opts renderOptions) {
 		// prefer to be able to use <b> and <i> for diff and filenames respectively
 		fmt.Fprintf(w, "<pre><code>")
 	}
-	fmt.Fprintf(w, "%s", cmds.Bytes())
+	cmdsStr := cmds.String()
+	cmdsStr = template.HTMLEscapeString(cmdsStr)
+	cmdsStr = replaceBraces(cmdsStr)
+	fmt.Fprintf(w, "%s", cmdsStr)
 	fmt.Fprintf(w, "</code></pre>")
 }
 

--- a/cmd/preguide/testdata/all_directives.txt
+++ b/cmd/preguide/testdata/all_directives.txt
@@ -111,7 +111,7 @@ title: A test with all directives
 
 # Step 1
 
-<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMKKGNkICQobWt0ZW1wIC1kKTsgZWNobyBoZWxsbykK"><code class="language-.term1">$ echo "Hello, world! I am a #Command"
+<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMKKGNkICQobWt0ZW1wIC1kKTsgZWNobyBoZWxsbykK"><code class="language-.term1">$ echo &#34;Hello, world! I am a #Command&#34;
 Hello, world! I am a #Command
 $ touch blah
 $ false
@@ -123,7 +123,7 @@ hello
 
 # Step 2
 
-<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmRGaWxlIgo="><code class="language-.term1">$ echo "Hello, world! I am a #CommandFile"
+<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmRGaWxlIgo="><code class="language-.term1">$ echo &#34;Hello, world! I am a #CommandFile&#34;
 Hello, world! I am a #CommandFile
 </code></pre>
 

--- a/cmd/preguide/testdata/env_template.txt
+++ b/cmd/preguide/testdata/env_template.txt
@@ -77,7 +77,7 @@ title: A test with all directives
 ---
 # Step 1
 
-<pre data-command-src="ZWNobyAtbiAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="><code class="language-.term1">$ echo -n "The answer is: &#123;&#123;.GREETING&#125;&#125;!"
+<pre data-command-src="ZWNobyAtbiAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="><code class="language-.term1">$ echo -n &#34;The answer is: &#123;&#123;.GREETING&#125;&#125;!&#34;
 The answer is: &#123;&#123;.GREETING&#125;&#125;!
 </code></pre>
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
@@ -130,7 +130,7 @@ Delims: ["{{", "}}"]
 -- myguide/go115_en.markdown.raw.golden --
 # Step 1
 
-$ echo -n "The answer is: &#123;&#123;.GREETING&#125;&#125;!"
+$ echo -n &#34;The answer is: &#123;&#123;.GREETING&#125;&#125;!&#34;
 The answer is: Hello, world!!
 </code></pre>
 -- myguide/go115_en_log.txt.raw.golden --

--- a/cmd/preguide/testdata/github.txt
+++ b/cmd/preguide/testdata/github.txt
@@ -61,7 +61,7 @@ And some doubles {{ .hello }}
 -- myguide/go115_en.markdown.golden --
 # Step 1
 
-<pre><code>$ echo "Hello, world! I am a #Command &#123; ok &#125; &#123;&#123; .ok &#125;&#125;"
+<pre><code>$ echo &#34;Hello, world! I am a #Command &#123; ok &#125; &#123;&#123; .ok &#125;&#125;&#34;
 Hello, world! I am a #Command &#123; ok &#125; &#123;&#123; .ok &#125;&#125;
 $ touch blah
 $ false

--- a/cmd/preguide/testdata/out_refs.txt
+++ b/cmd/preguide/testdata/out_refs.txt
@@ -74,7 +74,7 @@ world
 
 Here are some commands:
 
-<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISIKdG91Y2ggYmxhaApmYWxzZQpscwo="><code class="language-.term1">$ echo "Hello, world!"
+<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISIKdG91Y2ggYmxhaApmYWxzZQpscwo="><code class="language-.term1">$ echo &#34;Hello, world!&#34;
 Hello, world!
 $ touch blah
 $ false

--- a/cmd/preguide/testdata/parallel.txt
+++ b/cmd/preguide/testdata/parallel.txt
@@ -103,7 +103,7 @@ title: A test with all directives
 ---
 # Step 1
 
-<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"><code class="language-.term1">$ echo "Hello, world! I am a #Command"
+<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"><code class="language-.term1">$ echo &#34;Hello, world! I am a #Command&#34;
 Hello, world! I am a #Command
 $ touch blah
 $ false
@@ -137,7 +137,7 @@ title: A test with all directives
 ---
 # Step 1
 
-<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"><code class="language-.term1">$ echo "Hello, world! I am a #Command"
+<pre data-command-src="ZWNobyAiSGVsbG8sIHdvcmxkISBJIGFtIGEgI0NvbW1hbmQiCnRvdWNoIGJsYWgKZmFsc2UKbHMK"><code class="language-.term1">$ echo &#34;Hello, world! I am a #Command&#34;
 Hello, world! I am a #Command
 $ touch blah
 $ false

--- a/cmd/preguide/testdata/prestep.txt
+++ b/cmd/preguide/testdata/prestep.txt
@@ -118,7 +118,7 @@ title: A test with all directives
 ---
 # Step 1
 
-<pre data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="><code class="language-.term1">$ echo "The answer is: &#123;&#123;.GREETING&#125;&#125;!"
+<pre data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="><code class="language-.term1">$ echo &#34;The answer is: &#123;&#123;.GREETING&#125;&#125;!&#34;
 The answer is: &#123;&#123;.GREETING&#125;&#125;!
 </code></pre>
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
@@ -133,7 +133,7 @@ title: A test with all directives
 ---
 # Step 1
 
-<pre data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="><code class="language-.term1">$ echo "The answer is: &#123;&#123;.GREETING&#125;&#125;!"
+<pre data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3suR1JFRVRJTkd9fSEiCg=="><code class="language-.term1">$ echo &#34;The answer is: &#123;&#123;.GREETING&#125;&#125;!&#34;
 The answer is: &#123;&#123;.GREETING&#125;&#125;!
 </code></pre>
 <script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>

--- a/cmd/preguide/testdata/prestep_file.txt
+++ b/cmd/preguide/testdata/prestep_file.txt
@@ -81,9 +81,9 @@ title: A test with all directives
 The heading here is actually invalid in Jekyll mode because Jekyll will try
 and interpret the braces.
 
-<pre data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3t7LkdSRUVUSU5HfX19ISIKZWNobyAiVGhpcyBpcyBhIHRlc3Qge30iCg=="><code class="language-.term1">$ echo "The answer is: &#123;&#123;&#123;.GREETING&#125;&#125;&#125;!"
+<pre data-command-src="ZWNobyAiVGhlIGFuc3dlciBpczoge3t7LkdSRUVUSU5HfX19ISIKZWNobyAiVGhpcyBpcyBhIHRlc3Qge30iCg=="><code class="language-.term1">$ echo &#34;The answer is: &#123;&#123;&#123;.GREETING&#125;&#125;&#125;!&#34;
 The answer is: &#123;&#123;&#123;.GREETING&#125;&#125;&#125;!
-$ echo "This is a test &#123;&#125;"
+$ echo &#34;This is a test &#123;&#125;&#34;
 This is a test &#123;&#125;
 </code></pre>
 

--- a/cmd/preguide/testdata/renderer_diff.txt
+++ b/cmd/preguide/testdata/renderer_diff.txt
@@ -69,7 +69,7 @@ title: A test with all directives
 ---
 # Step 1
 
-<pre data-command-src="ZWNobyAtbiAiSGVsbG8iCg=="><code class="language-.term1">$ echo -n "Hello"
+<pre data-command-src="ZWNobyAtbiAiSGVsbG8iCg=="><code class="language-.term1">$ echo -n &#34;Hello&#34;
 Hello
 </code></pre>
 

--- a/cmd/preguide/testdata/renderers.txt
+++ b/cmd/preguide/testdata/renderers.txt
@@ -105,7 +105,7 @@ title: A test with all directives
 ---
 # Step 1
 
-<pre data-command-src="ZWNobyAtbiAiSGVsbG8iCg=="><code class="language-.term1">$ echo -n "Hello"
+<pre data-command-src="ZWNobyAtbiAiSGVsbG8iCg=="><code class="language-.term1">$ echo -n &#34;Hello&#34;
 Hello
 </code></pre>
 
@@ -122,7 +122,7 @@ title: A test with all directives
 ---
 # Step 1
 
-<pre data-command-src="ZWNobyAtbiAiSGVsbG8iCg=="><code class="language-.term1">$ echo -n "Hello"
+<pre data-command-src="ZWNobyAtbiAiSGVsbG8iCg=="><code class="language-.term1">$ echo -n &#34;Hello&#34;
 Hello
 </code></pre>
 

--- a/cmd/preguide/testdata/sanitise_git.txt
+++ b/cmd/preguide/testdata/sanitise_git.txt
@@ -129,7 +129,7 @@ Initialized empty Git repository in /home/gopher/example/.git/
 <pre data-upload-path="L2hvbWUvZ29waGVyL2V4YW1wbGU=" data-upload-src="UkVBRE1FLm1k:VGhpcyBpcyBhIHRlc3Qu" data-upload-term=".term1"><code class="language-md">This is a test.</code></pre>
 
 <pre data-command-src="Z2l0IGFkZCAtQQpnaXQgY29tbWl0IC1hbSAnSW5pdGlhbCBjb21taXQnCg=="><code class="language-.term1">$ git add -A
-$ git commit -am 'Initial commit'
+$ git commit -am &#39;Initial commit&#39;
 [main (root-commit) abcd123] Initial commit
  1 file changed, 1 insertion(+)
  create mode 100644 README.md
@@ -142,7 +142,7 @@ abcdefg123456789
 <pre data-upload-path="L2hvbWUvZ29waGVyL2V4YW1wbGU=" data-upload-src="UkVBRE1FLm1k:VGhpcyBpcyBhIHRlc3QuLi4gYWdhaW4h" data-upload-term=".term1"><code class="language-md">This is a test... again!</code></pre>
 
 <pre data-command-src="Z2l0IGFkZCAtQQpnaXQgY29tbWl0IC1hbSAnU2Vjb25kIGNvbW1pdCcK"><code class="language-.term1">$ git add -A
-$ git commit -am 'Second commit'
+$ git commit -am &#39;Second commit&#39;
 [main abcd123] Second commit
  1 file changed, 1 insertion(+), 1 deletion(-)
 </code></pre>


### PR DESCRIPTION
This also simplifies the logic around replacing of braces in command
blocks. The sanitisation is required because command blocks are now
emitted as `<pre><code>` blocks, and hence are not subject to sanitisation
by the subsequent markdown processor (e.g. Jekyll)