### PR TITLE
cmd/preguide: Validate step must ensure guide is concrete

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -676,7 +676,7 @@ func (pdc *processDirContext) loadAndValidateSteps(g *guide, mustContainGuide bo
 	// where required, but will not have source information (which is required
 	// below)
 	gv = pdc.schemas.Guide.Unify(gv)
-	err = gv.Validate()
+	err = gv.Validate(cue.Concrete(true))
 	if err != nil {
 		var errstr strings.Builder
 		errors.Print(&errstr, err, nil)


### PR DESCRIPTION
This prevents errors in the subsequent decode (at which point they are
more convoluted)