### PR TITLE
deps: use cuelang.org/go v0.3.0-beta.3.0.20210125164657-726d93e418af

### DIFF
--- a/cmd/preguide/testdata/limitations.txt
+++ b/cmd/preguide/testdata/limitations.txt
@@ -11,7 +11,7 @@ stderr 'demarkdown/guide/de.markdown: "de" is not a valid language for this guid
 # hence non-English steps should fail
 ! preguide gen -out desteps/_output -dir desteps
 ! stdout .+
-stderr 'desteps/guide: mod.com/desteps/guide does not satisfy github.com/play-with-go/preguide.#Guide: #Guide.Steps.step1: empty disjunction'
+stderr 'desteps/guide: mod.com/desteps/guide does not satisfy github.com/play-with-go/preguide.#Guide: #Guide.Steps.step1: 1 errors in empty disjunction'
 stderr '#Guide.Steps.step1: field `de` not allowed'
 
 # Only support a single terminal

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/play-with-go/preguide
 go 1.15
 
 require (
-	cuelang.org/go v0.3.0-alpha5.0.20201129154919-e77ccb1c2e96
+	cuelang.org/go v0.3.0-beta.3.0.20210125164657-726d93e418af
 	github.com/gohugoio/hugo v0.69.2
 	github.com/google/go-cmp v0.4.0
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRq
 contrib.go.opencensus.io/exporter/stackdriver v0.11.0/go.mod h1:hA7rlmtavV03FGxzWXAPBUnZeZBhWN/QYQAuMtxc9Bk=
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.0.0-20190131005048-21591786a5e0/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
-cuelang.org/go v0.3.0-alpha5.0.20201129154919-e77ccb1c2e96 h1:D5l1EBi57KHntmLBF94By+EZDFvHN9WUEJoM4ZGm9QI=
-cuelang.org/go v0.3.0-alpha5.0.20201129154919-e77ccb1c2e96/go.mod h1:NwRWsRzQvqkhCHdkIjFBKo9ujPd1OQLZzugDjElHh8Q=
+cuelang.org/go v0.3.0-beta.3.0.20210125164657-726d93e418af h1:sHbIQ2HcXQMxHI0IYnizBeS90XBtFWLdmRHFr3Z/01c=
+cuelang.org/go v0.3.0-beta.3.0.20210125164657-726d93e418af/go.mod h1:NwRWsRzQvqkhCHdkIjFBKo9ujPd1OQLZzugDjElHh8Q=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-amqp-common-go v1.1.3/go.mod h1:FhZtXirFANw40UXI2ntweO+VOkfaw8s6vZxUiRhLYW8=
 github.com/Azure/azure-amqp-common-go v1.1.4/go.mod h1:FhZtXirFANw40UXI2ntweO+VOkfaw8s6vZxUiRhLYW8=


### PR DESCRIPTION
Current latest.