### PR TITLE
preguide: rework preguide schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/play-with-go/preguide
 go 1.15
 
 require (
-	cuelang.org/go v0.3.0-beta.5.0.20210217114833-77e6b51a0f14
+	cuelang.org/go v0.3.0-beta.5.0.20210217114852-2c86835c2019
 	github.com/gohugoio/hugo v0.69.2
 	github.com/google/go-cmp v0.4.0
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRq
 contrib.go.opencensus.io/exporter/stackdriver v0.11.0/go.mod h1:hA7rlmtavV03FGxzWXAPBUnZeZBhWN/QYQAuMtxc9Bk=
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.0.0-20190131005048-21591786a5e0/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
-cuelang.org/go v0.3.0-beta.5.0.20210217114833-77e6b51a0f14 h1:+1eo+JhIIgnJ/8i4x22ENq9pEchFZMEJTSUDW7mGM30=
-cuelang.org/go v0.3.0-beta.5.0.20210217114833-77e6b51a0f14/go.mod h1:Ikvs157igkGV5gFUdYSFa+lWp/CDteVhubPTXyvPRtA=
+cuelang.org/go v0.3.0-beta.5.0.20210217114852-2c86835c2019 h1:mj5d8fHqqDGVAeGwO5FeLsYAOIYL+ifjySl0v18NVyo=
+cuelang.org/go v0.3.0-beta.5.0.20210217114852-2c86835c2019/go.mod h1:Ikvs157igkGV5gFUdYSFa+lWp/CDteVhubPTXyvPRtA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-amqp-common-go v1.1.3/go.mod h1:FhZtXirFANw40UXI2ntweO+VOkfaw8s6vZxUiRhLYW8=
 github.com/Azure/azure-amqp-common-go v1.1.4/go.mod h1:FhZtXirFANw40UXI2ntweO+VOkfaw8s6vZxUiRhLYW8=

--- a/internal/embed/gen_bindata.go
+++ b/internal/embed/gen_bindata.go
@@ -106,7 +106,6 @@ func out_out_cue() ([]byte, error) {
 var _preguide_cue = []byte(`package preguide
 
 import (
-	"list"
 	"path"
 	"regexp"
 )
@@ -124,80 +123,7 @@ import (
 	Languages: [...#Language]
 	Languages: ["en"]
 
-	#Step: (#Command | #CommandFile | #Upload | #UploadFile ) & {
-		Name:     string
-		StepType: #StepType
-		Terminal: string
-	}
-
 	FilenameComment: *false | bool
-
-	_#stepCommon: {
-		Name:     string
-		StepType: #StepType
-		Terminal: string
-	}
-
-	_#commandCommon: {
-		_#stepCommon
-
-		// RandomReplace indicates the entire output from this command block
-		// should be used to sanitise the output from the entire script,
-		// replacing the "random" output from this command block with the
-		// value specified in RandomReplace.
-		RandomReplace?: string
-
-		// DoNotTrim indicates that when RandomReplace is set, its value
-		// should not be trimmed (the default is to trim the trailing \n
-		// from the output) prior to sanitising the output from the script
-		DoNotTrim: *false | bool
-
-		// InformationOnly indicates that this field is not required for the
-		// successful execution of the script. Generally this is used by
-		// command blocks which are outputting random data for post-execution
-		// sanitisation, e.g. git commits.
-		InformationOnly: *false | bool
-	}
-
-	_#uploadCommon: {
-		_#stepCommon
-
-		Target: string
-
-		// The language of the content being uploaded, e.g. go
-		// This gets used on the markdown code block, hence the
-		// values supported here are a function of the markdown
-		// parse on the other end.
-		Language: *regexp.FindSubmatch("^.(.*)", path.Ext(Target))[1] | string
-
-		// Renderer defines how the upload file contents will be
-		// rendered to the user in the guide.
-		Renderer: #Renderer
-	}
-
-	#Command: {
-		_#commandCommon
-		StepType: #StepTypeCommand
-		Source:   string
-	}
-
-	#CommandFile: {
-		_#commandCommon
-		StepType: #StepTypeCommandFile
-		Path:     string
-	}
-
-	#Upload: {
-		_#uploadCommon
-		StepType: #StepTypeUpload
-		Source:   string
-	}
-
-	#UploadFile: {
-		_#uploadCommon
-		StepType: #StepTypeUploadFile
-		Path:     string
-	}
 
 	// Networks is the list of docker networks to connect to when running
 	// this guide.
@@ -215,11 +141,8 @@ import (
 	Delims: *["{{", "}}"] | [string, string]
 
 	Steps: [name=string]: #Step & {
-		// TODO: remove post upgrade to latest CUE? Because at that point
-		// the defaulting in #TerminalName will work
-		Terminal: *#TerminalNames[0] | string
-
-		Name: name
+		Name:     name
+		Terminal: _#TerminalName
 	}
 
 	// Scenarios define the various images under which this guide will be
@@ -229,19 +152,17 @@ import (
 		Name: name
 	}
 
+	// This "forces" the user to define the image for every scenario for
+	// every terminal they declare
 	for scenario, _ in Scenarios for terminal, _ in Terminals {
 		Terminals: "\(terminal)": Scenarios: "\(scenario)": #TerminalScenario
 	}
 
-	// TODO: remove post upgrade to latest CUE? Because at that point
-	// the use of or() will work, which will give a better error message
-	#TerminalNames: [ for k, _ in Terminals {k}]
-	#ok: true & and([ for s in Steps {list.Contains(#TerminalNames, s.Terminal)}])
+	_#TerminalNames: [ for k, _ in Terminals {k}]
+	_#TerminalName: *_#TerminalNames[0] | or(_#TerminalNames)
 
 	// Terminals defines the required remote VMs for a given guide
-	Terminals: [string]: #Terminal
-
-	Terminals: [name=string]: {
+	Terminals: [name=string]: #Terminal & {
 		Name: name
 	}
 
@@ -285,11 +206,74 @@ import (
 // in #Guide, because those definitions rely on references to Terminals
 // which only makes sense in the context of a #Guide instance
 
-#Step:        #Guide.#Step
-#Command:     #Guide.#Command
-#CommandFile: #Guide.#CommandFile
-#Upload:      #Guide.#Upload
-#UploadFile:  #Guide.#UploadFile
+_stepCommon: {
+	Name:     string
+	StepType: #StepType
+	Terminal: string
+}
+
+_#commandCommon: {
+	_stepCommon
+
+	// RandomReplace indicates the entire output from this command block
+	// should be used to sanitise the output from the entire script,
+	// replacing the "random" output from this command block with the
+	// value specified in RandomReplace.
+	RandomReplace?: string
+
+	// DoNotTrim indicates that when RandomReplace is set, its value
+	// should not be trimmed (the default is to trim the trailing \n
+	// from the output) prior to sanitising the output from the script
+	DoNotTrim: *false | bool
+
+	// InformationOnly indicates that this field is not required for the
+	// successful execution of the script. Generally this is used by
+	// command blocks which are outputting random data for post-execution
+	// sanitisation, e.g. git commits.
+	InformationOnly: *false | bool
+}
+
+_#uploadCommon: {
+	_stepCommon
+
+	Target: string
+
+	// The language of the content being uploaded, e.g. go
+	// This gets used on the markdown code block, hence the
+	// values supported here are a function of the markdown
+	// parse on the other end.
+	Language: *regexp.FindSubmatch("^.(.*)", path.Ext(Target))[1] | string
+
+	// Renderer defines how the upload file contents will be
+	// rendered to the user in the guide.
+	Renderer: #Renderer
+}
+
+#Step: (#Command | #CommandFile | #Upload | #UploadFile) & _stepCommon
+
+#Command: {
+	_#commandCommon
+	StepType: #StepTypeCommand
+	Source:   string
+}
+
+#CommandFile: {
+	_#commandCommon
+	StepType: #StepTypeCommandFile
+	Path:     string
+}
+
+#Upload: {
+	_#uploadCommon
+	StepType: #StepTypeUpload
+	Source:   string
+}
+
+#UploadFile: {
+	_#uploadCommon
+	StepType: #StepTypeUploadFile
+	Path:     string
+}
 
 // #PrestepServiceConfig is a mapping from prestep package path to endpoint
 // configuration.
@@ -340,17 +324,6 @@ _#rendererCommon: {
 	RendererType: #RendererTypeDiff
 	Pre:          string
 }
-
-// Post upgrade to latest CUE we have a number of things to change/test, with /
-// reference to https://gist.github.com/myitcv/399ed50f792b49ae7224ee5cb3e504fa#file-304b02e-cue
-//
-// 1. Move to the use of #TerminalName (probably hidden) as a type for a terminal's
-// name in _#stepCommon
-// 2. Try and move to the advanced definition of Steps: [string]: [lang] to be the
-// disjunction of #Step or [scenario]: #Step
-// 3. Ensure that a step's name can be defaulted for this advanced definition (i.e.
-// that if a step is specified at the language level its name defaults, but also
-// if it is specified at the scenario level)
 `)
 
 func preguide_cue() ([]byte, error) {

--- a/preguide.cue
+++ b/preguide.cue
@@ -1,7 +1,6 @@
 package preguide
 
 import (
-	"list"
 	"path"
 	"regexp"
 )
@@ -19,80 +18,7 @@ import (
 	Languages: [...#Language]
 	Languages: ["en"]
 
-	#Step: (#Command | #CommandFile | #Upload | #UploadFile ) & {
-		Name:     string
-		StepType: #StepType
-		Terminal: string
-	}
-
 	FilenameComment: *false | bool
-
-	_#stepCommon: {
-		Name:     string
-		StepType: #StepType
-		Terminal: string
-	}
-
-	_#commandCommon: {
-		_#stepCommon
-
-		// RandomReplace indicates the entire output from this command block
-		// should be used to sanitise the output from the entire script,
-		// replacing the "random" output from this command block with the
-		// value specified in RandomReplace.
-		RandomReplace?: string
-
-		// DoNotTrim indicates that when RandomReplace is set, its value
-		// should not be trimmed (the default is to trim the trailing \n
-		// from the output) prior to sanitising the output from the script
-		DoNotTrim: *false | bool
-
-		// InformationOnly indicates that this field is not required for the
-		// successful execution of the script. Generally this is used by
-		// command blocks which are outputting random data for post-execution
-		// sanitisation, e.g. git commits.
-		InformationOnly: *false | bool
-	}
-
-	_#uploadCommon: {
-		_#stepCommon
-
-		Target: string
-
-		// The language of the content being uploaded, e.g. go
-		// This gets used on the markdown code block, hence the
-		// values supported here are a function of the markdown
-		// parse on the other end.
-		Language: *regexp.FindSubmatch("^.(.*)", path.Ext(Target))[1] | string
-
-		// Renderer defines how the upload file contents will be
-		// rendered to the user in the guide.
-		Renderer: #Renderer
-	}
-
-	#Command: {
-		_#commandCommon
-		StepType: #StepTypeCommand
-		Source:   string
-	}
-
-	#CommandFile: {
-		_#commandCommon
-		StepType: #StepTypeCommandFile
-		Path:     string
-	}
-
-	#Upload: {
-		_#uploadCommon
-		StepType: #StepTypeUpload
-		Source:   string
-	}
-
-	#UploadFile: {
-		_#uploadCommon
-		StepType: #StepTypeUploadFile
-		Path:     string
-	}
 
 	// Networks is the list of docker networks to connect to when running
 	// this guide.
@@ -110,11 +36,8 @@ import (
 	Delims: *["{{", "}}"] | [string, string]
 
 	Steps: [name=string]: #Step & {
-		// TODO: remove post upgrade to latest CUE? Because at that point
-		// the defaulting in #TerminalName will work
-		Terminal: *#TerminalNames[0] | string
-
-		Name: name
+		Name:     name
+		Terminal: _#TerminalName
 	}
 
 	// Scenarios define the various images under which this guide will be
@@ -124,19 +47,17 @@ import (
 		Name: name
 	}
 
+	// This "forces" the user to define the image for every scenario for
+	// every terminal they declare
 	for scenario, _ in Scenarios for terminal, _ in Terminals {
 		Terminals: "\(terminal)": Scenarios: "\(scenario)": #TerminalScenario
 	}
 
-	// TODO: remove post upgrade to latest CUE? Because at that point
-	// the use of or() will work, which will give a better error message
-	#TerminalNames: [ for k, _ in Terminals {k}]
-	#ok: true & and([ for s in Steps {list.Contains(#TerminalNames, s.Terminal)}])
+	_#TerminalNames: [ for k, _ in Terminals {k}]
+	_#TerminalName: *_#TerminalNames[0] | or(_#TerminalNames)
 
 	// Terminals defines the required remote VMs for a given guide
-	Terminals: [string]: #Terminal
-
-	Terminals: [name=string]: {
+	Terminals: [name=string]: #Terminal & {
 		Name: name
 	}
 
@@ -180,11 +101,74 @@ import (
 // in #Guide, because those definitions rely on references to Terminals
 // which only makes sense in the context of a #Guide instance
 
-#Step:        #Guide.#Step
-#Command:     #Guide.#Command
-#CommandFile: #Guide.#CommandFile
-#Upload:      #Guide.#Upload
-#UploadFile:  #Guide.#UploadFile
+_stepCommon: {
+	Name:     string
+	StepType: #StepType
+	Terminal: string
+}
+
+_#commandCommon: {
+	_stepCommon
+
+	// RandomReplace indicates the entire output from this command block
+	// should be used to sanitise the output from the entire script,
+	// replacing the "random" output from this command block with the
+	// value specified in RandomReplace.
+	RandomReplace?: string
+
+	// DoNotTrim indicates that when RandomReplace is set, its value
+	// should not be trimmed (the default is to trim the trailing \n
+	// from the output) prior to sanitising the output from the script
+	DoNotTrim: *false | bool
+
+	// InformationOnly indicates that this field is not required for the
+	// successful execution of the script. Generally this is used by
+	// command blocks which are outputting random data for post-execution
+	// sanitisation, e.g. git commits.
+	InformationOnly: *false | bool
+}
+
+_#uploadCommon: {
+	_stepCommon
+
+	Target: string
+
+	// The language of the content being uploaded, e.g. go
+	// This gets used on the markdown code block, hence the
+	// values supported here are a function of the markdown
+	// parse on the other end.
+	Language: *regexp.FindSubmatch("^.(.*)", path.Ext(Target))[1] | string
+
+	// Renderer defines how the upload file contents will be
+	// rendered to the user in the guide.
+	Renderer: #Renderer
+}
+
+#Step: (#Command | #CommandFile | #Upload | #UploadFile) & _stepCommon
+
+#Command: {
+	_#commandCommon
+	StepType: #StepTypeCommand
+	Source:   string
+}
+
+#CommandFile: {
+	_#commandCommon
+	StepType: #StepTypeCommandFile
+	Path:     string
+}
+
+#Upload: {
+	_#uploadCommon
+	StepType: #StepTypeUpload
+	Source:   string
+}
+
+#UploadFile: {
+	_#uploadCommon
+	StepType: #StepTypeUploadFile
+	Path:     string
+}
 
 // #PrestepServiceConfig is a mapping from prestep package path to endpoint
 // configuration.
@@ -235,14 +219,3 @@ _#rendererCommon: {
 	RendererType: #RendererTypeDiff
 	Pre:          string
 }
-
-// Post upgrade to latest CUE we have a number of things to change/test, with /
-// reference to https://gist.github.com/myitcv/399ed50f792b49ae7224ee5cb3e504fa#file-304b02e-cue
-//
-// 1. Move to the use of #TerminalName (probably hidden) as a type for a terminal's
-// name in _#stepCommon
-// 2. Try and move to the advanced definition of Steps: [string]: [lang] to be the
-// disjunction of #Step or [scenario]: #Step
-// 3. Ensure that a step's name can be defaulted for this advanced definition (i.e.
-// that if a step is specified at the language level its name defaults, but also
-// if it is specified at the scenario level)


### PR DESCRIPTION
With a number of recent changes/improvements in CUE we can greatly
simplify the preguide schema. This also serves as preparation for
changes that will be made as part of #64.

Note this also upgrades to the latest CUE, because this refactored
schema is not susceptible to cuelang/cue#784.

For #115