### PR TITLE
cmd/preguide: ignore build constraints when loading config

### DIFF
--- a/cmd/preguide/gencmd.go
+++ b/cmd/preguide/gencmd.go
@@ -438,7 +438,8 @@ func (gc *genCmd) loadConfig() {
 	// res will hold the config result
 	var res cue.Value
 
-	bis := load.Instances(gc.fConfigs, nil)
+	// TODO: gross hack of using AllCUEFiles below
+	bis := load.Instances(gc.fConfigs, &load.Config{AllCUEFiles: true})
 	for i, bi := range bis {
 		inst, err := gc.runtime.Build(bi)
 		check(err, "failed to load config from %v: %v", gc.fConfigs[i], err)


### PR DESCRIPTION
This is a hack. But it works for now. To properly fix this hack we need
to provide flags for specifying the tags that should be passed during
the loading of config _and_ the guides themselves (because they might be
different... and CUE is stricter about tags being used in files)