### PR TITLE
cmd/preguide: add support for tags

### DIFF
--- a/cmd/preguide/testdata/github.txt
+++ b/cmd/preguide/testdata/github.txt
@@ -72,8 +72,6 @@ blah
 # Step 2
 
 ```bash
-# /scripts/somewhere.bash
-
 #!/usr/bin/env bash
 
 echo "Hello, world! I am an #Upload"

--- a/cmd/preguide/testdata/help.txt
+++ b/cmd/preguide/testdata/help.txt
@@ -80,3 +80,5 @@ usage: preguide gen
 	        additional arguments to pass to the script that runs for a terminal. Format -run=$terminalName=args...; can appear multiple times
 	  -skipcache
 	        whether to skip any output cache checking
+	  -t value
+	        tags for the CUE load

--- a/cmd/preguide/testdata/tags.txt
+++ b/cmd/preguide/testdata/tags.txt
@@ -1,0 +1,75 @@
+# Test passing tags to preguide works
+
+# No tags
+preguide gen -out _output
+! stdout .+
+! stderr .+
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.notags.golden
+
+# Tags
+preguide gen -t blah=tags -out _output
+! stdout .+
+! stderr .+
+cmp _output/myguide_go115_en.markdown myguide/go115_en.markdown.tags.golden
+
+-- myguide/en.markdown --
+---
+title: A test with all directives
+---
+
+# Step 0
+
+{{ step "step0" }}
+
+-- myguide/steps.cue --
+package steps
+
+import "github.com/play-with-go/preguide"
+
+_example: *"no tags" | string @tag(blah)
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+FilenameComment: true
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "this_will_never_be_used"
+}
+
+Steps: step0: preguide.#Command & {
+	Source: """
+echo \(_example)
+"""
+}
+
+-- myguide/go115_en.markdown.notags.golden --
+---
+guide: myguide
+lang: en
+title: A test with all directives
+---
+
+# Step 0
+
+<pre data-command-src="ZWNobyBubyB0YWdzCg=="><code class="language-.term1">$ echo no tags
+no tags
+</code></pre>
+
+<script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>
+-- myguide/go115_en.markdown.tags.golden --
+---
+guide: myguide
+lang: en
+title: A test with all directives
+---
+
+# Step 0
+
+<pre data-command-src="ZWNobyB0YWdzCg=="><code class="language-.term1">$ echo tags
+tags
+</code></pre>
+
+<script>let pageGuide="myguide"; let pageLanguage="en"; let pageScenario="go115";</script>


### PR DESCRIPTION
Tags are like the -t flag to cmd/cue, and hence act like injection.