### PR TITLE
cmd/preguide: sanitise more of go env output

### DIFF
--- a/sanitisers/cmdgo/go_test.go
+++ b/sanitisers/cmdgo/go_test.go
@@ -130,7 +130,6 @@ CGO_CXXFLAGS="-g -O2"
 CGO_FFLAGS="-g -O2"
 CGO_LDFLAGS="-g -O2"
 PKG_CONFIG="pkg-config"
-GOGCCFLAGS="fake_gcc_flags"
 `,
 		},
 	}


### PR DESCRIPTION
(see commit message)

